### PR TITLE
Add pushgateway related configs

### DIFF
--- a/config/v2/configV2.go
+++ b/config/v2/configV2.go
@@ -140,7 +140,10 @@ func (c *GrokConfig) addDefaults() {}
 //add default job name
 func (c *MetricsConfig) addDefaults() {
 	for _, metric := range *c {
-		metric.JobName = "grok_exporter"
+        if len(metric.JobName) == 0 {
+            metric.JobName = "grok_exporter"    
+        }
+		
 	}
 }
 

--- a/config/v2/configV2.go
+++ b/config/v2/configV2.go
@@ -140,10 +140,10 @@ func (c *GrokConfig) addDefaults() {}
 //add default job name
 func (c *MetricsConfig) addDefaults() {
 	for _, metric := range *c {
-        if len(metric.JobName) == 0 {
-            metric.JobName = "grok_exporter"    
-        }
-		
+		if len(metric.JobName) == 0 {
+			metric.JobName = "grok_exporter"
+		}
+
 	}
 }
 

--- a/config/v2/configV2.go
+++ b/config/v2/configV2.go
@@ -138,10 +138,10 @@ func (c *InputConfig) addDefaults() {
 func (c *GrokConfig) addDefaults() {}
 
 //add default job name
-func (c *MetricConfig) addDefaults() {
-	if c.JobName == "" {
-		c.JobName = "grok_exporter"
-	}
+func (c *MetricsConfig) addDefaults() {
+	for _, metric := range c {
+        metric.JobName = "grok_exporter"
+    }
 }
 
 func (c *ServerConfig) addDefaults() {

--- a/config/v2/configV2.go
+++ b/config/v2/configV2.go
@@ -43,7 +43,7 @@ func (cfg *Config) String() string {
 }
 
 type GlobalConfig struct {
-	ConfigVersion int `yaml:"config_version,omitempty"`
+	ConfigVersion   int    `yaml:"config_version,omitempty"`
 	PushgatewayAddr string `yaml:"pushgateway_addr,omitempty"` // add pushgateway address <ip>:<port>
 }
 
@@ -59,17 +59,17 @@ type GrokConfig struct {
 }
 
 type MetricConfig struct {
-	Type           string               `yaml:",omitempty"`
-	Name           string               `yaml:",omitempty"`
-	Help           string               `yaml:",omitempty"`
-	Match          string               `yaml:",omitempty"`
+	Type  string `yaml:",omitempty"`
+	Name  string `yaml:",omitempty"`
+	Help  string `yaml:",omitempty"`
+	Match string `yaml:",omitempty"`
 
 	/**************pushgateway related configs*******************/
-	Pushgateway    bool					`yaml:",omitempty"` //flag for if push metric to pushgateway or not 
-	JobName		   string 				`yaml:"job_name,omitempty"` //job name used to push metric to pushgateway
+	Pushgateway    bool                 `yaml:",omitempty"`             //flag for if push metric to pushgateway or not
+	JobName        string               `yaml:"job_name,omitempty"`     //job name used to push metric to pushgateway
 	DeleteMatch    string               `yaml:"delete_match,omitempty"` //if match, metric will be deleted from pushgateway
-	GroupingKey    map[string]string 	`yaml:"grouping_key,omitempty"` //grouping key used to push and delete metric from pushgateway
-    GroupTemplates []templates.Template `yaml:"-"`
+	GroupingKey    map[string]string    `yaml:"grouping_key,omitempty"` //grouping key used to push and delete metric from pushgateway
+	GroupTemplates []templates.Template `yaml:"-"`
 	/**************end of pushgateway related configs************/
 
 	Value          string               `yaml:",omitempty"`
@@ -140,8 +140,8 @@ func (c *GrokConfig) addDefaults() {}
 //add default job name
 func (c *MetricsConfig) addDefaults() {
 	for _, metric := range *c {
-        metric.JobName = "grok_exporter"
-    }
+		metric.JobName = "grok_exporter"
+	}
 }
 
 func (c *ServerConfig) addDefaults() {
@@ -180,11 +180,11 @@ func (cfg *Config) validate() error {
 func (c *GlobalConfig) validate() error {
 	//ignore version validation
 	if len(c.PushgatewayAddr) > 0 {
-			reg := regexp.MustCompile("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:[0-9]{1,5}")
-			result := reg.FindString(c.PushgatewayAddr)
-			if result == "" {
-				return fmt.Errorf("Not valid pushgateway address, usage: <ip>>:<port>.")
-			}
+		reg := regexp.MustCompile("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:[0-9]{1,5}")
+		result := reg.FindString(c.PushgatewayAddr)
+		if result == "" {
+			return fmt.Errorf("Not valid pushgateway address, usage: <ip>>:<port>.")
+		}
 	}
 	return nil
 }
@@ -327,13 +327,13 @@ func (metric *MetricConfig) InitTemplates() error {
 	}
 	// validate grouping key
 	metric.GroupTemplates = make([]templates.Template, 0, len(metric.GroupingKey))
-    for name, templateString := range metric.GroupingKey {
-        tmplt, err = templates.New(name, templateString)
-        if err != nil {
-            return fmt.Errorf(msg, fmt.Sprintf("groupingKey %v", metric.Name), name, err.Error())
-        }
-        metric.GroupTemplates = append(metric.GroupTemplates, tmplt)
-    }
+	for name, templateString := range metric.GroupingKey {
+		tmplt, err = templates.New(name, templateString)
+		if err != nil {
+			return fmt.Errorf(msg, fmt.Sprintf("groupingKey %v", metric.Name), name, err.Error())
+		}
+		metric.GroupTemplates = append(metric.GroupTemplates, tmplt)
+	}
 
 	if len(metric.Value) > 0 {
 		metric.ValueTemplate, err = templates.New("__value__", metric.Value)

--- a/config/v2/configV2.go
+++ b/config/v2/configV2.go
@@ -139,7 +139,7 @@ func (c *GrokConfig) addDefaults() {}
 
 //add default job name
 func (c *MetricsConfig) addDefaults() {
-	for _, metric := range c {
+	for _, metric := range *c {
         metric.JobName = "grok_exporter"
     }
 }

--- a/config/v2/configV2.go
+++ b/config/v2/configV2.go
@@ -138,7 +138,7 @@ func (c *InputConfig) addDefaults() {
 func (c *GrokConfig) addDefaults() {}
 
 //add default job name
-func (c *MetricsConfig) addDefaults() {
+func (c *MetricConfig) addDefaults() {
 	if c.JobName == "" {
 		c.JobName = "grok_exporter"
 	}
@@ -177,7 +177,7 @@ func (cfg *Config) validate() error {
 	return nil
 }
 
-func (c *GrokConfig) validate() error {
+func (c *GlobalConfig) validate() error {
 	//ignore version validation
 	if len(c.PushgatewayAddr) > 0 {
 			reg := regexp.MustCompile("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}:[0-9]{1,5}")
@@ -332,7 +332,7 @@ func (metric *MetricConfig) InitTemplates() error {
         if err != nil {
             return fmt.Errorf(msg, fmt.Sprintf("groupingKey %v", metric.Name), name, err.Error())
         }
-        metric.GroupTemplates = append(metric.GroupingKey, tmplt)
+        metric.GroupTemplates = append(metric.GroupTemplates, tmplt)
     }
 
 	if len(metric.Value) > 0 {

--- a/exporter/grok.go
+++ b/exporter/grok.go
@@ -53,7 +53,7 @@ func VerifyFieldNames(m *v2.MetricConfig, regex *OnigurumaRegexp) error {
 }
 
 func VerifyGroupingKeyField(m *v2.MetricConfig, regex *OnigurumaRegexp) error {
-	for _, template := range m.LabelTemplates {
+	for _, template := range m.GroupTemplates {
 		for _, grokFieldName := range template.ReferencedGrokFields() {
 			if !regex.HasCaptureGroup(grokFieldName) {
 				return fmt.Errorf("%v: error in label %v: grok field %v not found in match pattern", m.Name, template.Name(), grokFieldName)

--- a/exporter/grok.go
+++ b/exporter/grok.go
@@ -52,6 +52,19 @@ func VerifyFieldNames(m *v2.MetricConfig, regex *OnigurumaRegexp) error {
 	return nil
 }
 
+func VerifyGroupingKeyField(m *v2.MetricConfig, regex *OnigurumaRegexp) error {
+	for _, template := range m.LabelTemplates {
+		for _, grokFieldName := range template.ReferencedGrokFields() {
+			if !regex.HasCaptureGroup(grokFieldName) {
+				return fmt.Errorf("%v: error in label %v: grok field %v not found in match pattern", m.Name, template.Name(), grokFieldName)
+			}
+		}
+	}
+	
+	return nil
+}
+
+
 // PATTERN_RE matches the %{..} patterns. There are three possibilities:
 // 1) %{USER}               - grok pattern
 // 2) %{IP:clientip}        - grok pattern with name

--- a/exporter/grok.go
+++ b/exporter/grok.go
@@ -60,10 +60,9 @@ func VerifyGroupingKeyField(m *v2.MetricConfig, regex *OnigurumaRegexp) error {
 			}
 		}
 	}
-	
+
 	return nil
 }
-
 
 // PATTERN_RE matches the %{..} patterns. There are three possibilities:
 // 1) %{USER}               - grok pattern

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -38,7 +38,7 @@ type incMetric struct {
 	regex     *OnigurumaRegexp
 	labels    []templates.Template
 	collector prometheus.Collector
-	metricVec prometheus.MetricVec
+	metricVec *prometheus.MetricVec
 	//pushgateway related configs
 	delete_regex *OnigurumaRegexp
 	pushgateway  bool
@@ -61,7 +61,7 @@ type observeMetric struct {
 	groupingKey  []templates.Template
 
 	collector   prometheus.Collector
-	metricVec   prometheus.MetricVec
+	metricVec   *prometheus.MetricVec
 	observeFunc func(m *OnigurumaMatchResult, val float64) error
 }
 

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -276,7 +276,11 @@ func (m *incMetric) Process(line string) (bool, bool, map[string]string, error) 
 		return true, deleteMatched, groupingKey, err
 
 	} else {
-		return false, deleteMatched, nil, nil
+		groupingKey, e := evalGroupingKey(matchResult, m.groupingKey)
+		if e != nil {
+			return false, deleteMatched, nil, fmt.Errorf("error while getting grouping key %v: %v", m.name, e.Error())
+		}
+		return false, deleteMatched, groupingKey, nil
 	}
 }
 

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -353,14 +353,14 @@ func (m *observeMetric) JobName() string {
 func evalGroupingKey(matchResult *OnigurumaMatchResult, templates []templates.Template) (map[string]string, error) {
 	result := make(map[string]string, len(templates))
 	for _, t := range templates {
-		for _, field := range t.ReferencedGrokFields() {
-			value, err := matchResult.Get(field)
-			if err != nil {
-				return nil, err
-			}
-			result[field] = value
+		value, err := evalTemplate(matchResult, t)
+		if err != nil {
+			return nil, err
 		}
+		result[t.Name()] = value
+
 	}
+	fmt.Println("[DEBUG] got groupingKey: %s", result)
 	return result, nil
 }
 

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -338,11 +338,11 @@ func (m *observeMetric) Name() string {
 	return m.name
 }
 
-func (m *incMetric) Collector() prometheus.Collector {
+func (m *incMetric) Collector() interface{} {
 	return m.collector
 }
 
-func (m *observeMetric) Collector() prometheus.Collector {
+func (m *observeMetric) Collector() interface{} {
 	return m.collector
 }
 

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -251,7 +251,7 @@ func NewSummaryMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_regex
 }
 
 // Return: true if the line matched, false if it didn't match.
-func (m *incMetric) Process(line string) (bool, bool, map[string][string], error) {
+func (m *incMetric) Process(line string) (bool, bool, map[string]string, error) {
 	matchResult, err := m.regex.Match(line)
 	deleteMatch, e := m.delete_regex.Match(line)
 	if err != nil  {

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -277,7 +277,7 @@ func (m *incMetric) Process(line string) (bool, bool, map[string]string, error) 
 
 	} else {
 		if deleteMatch.IsMatch() {
-			groupingKey, e := evalGroupingKey(deleteMatch, m.groupingKey)	
+			groupingKey, e := evalGroupingKey(deleteMatch, m.groupingKey)
 			if e != nil {
 				return false, true, nil, fmt.Errorf("error while getting grouping key %v: %v", m.name, e.Error())
 			}

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -28,6 +28,8 @@ type Metric interface {
 
 	// Returns true if the line matched, and false if the line didn't match.
 	Process(line string) (bool, bool, map[string]string, error)
+	NeedPush() (bool)
+	JobName() (string)
 }
 
 // Represents a Prometheus Counter
@@ -328,19 +330,19 @@ func (m *observeMetric) Collector() prometheus.Collector {
 	return m.collector
 }
 
-func (m *incMetric) push() bool {
+func (m *incMetric) NeedPush() bool {
 	return m.pushgateway
 }
 
-func (m *observeMetric) push() bool {
+func (m *observeMetric) NeedPush() bool {
 	return m.pushgateway
 }
 
-func (m *incMetric) getJobName() string {
+func (m *incMetric) JobName() string {
 	return m.job_name
 }
 
-func (m *observeMetric) getJobName() string {
+func (m *observeMetric) JobName() string {
 	return m.job_name
 }
 

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -38,7 +38,7 @@ type incMetric struct {
 	regex     *OnigurumaRegexp
 	labels    []templates.Template
 	collector prometheus.Collector
-    metricVec prometheus.MetricVec
+    metricVec *prometheus.MetricVec
 	//pushgateway related configs
 	delete_regex *OnigurumaRegexp
 	pushgateway  bool
@@ -61,7 +61,7 @@ type observeMetric struct {
 	groupingKey  []templates.Template
 
 	collector   prometheus.Collector
-	metricVec   prometheus.MetricVec
+	metricVec   *prometheus.MetricVec
 	observeFunc func(m *OnigurumaMatchResult, val float64) error
 }
 

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -25,6 +25,7 @@ import (
 type Metric interface {
 	Name() string
 	Collector() prometheus.Collector
+	MetricVec() *prometheus.MetricVec
 
 	// Returns true if the line matched, and false if the line didn't match.
 	Process(line string) (bool, bool, map[string]string, []string, error)
@@ -349,6 +350,14 @@ func (m *incMetric) Collector() prometheus.Collector {
 
 func (m *observeMetric) Collector() prometheus.Collector {
 	return m.collector
+}
+
+func (m *incMetric) MetricVec() *prometheus.MetricVec {
+	return m.metricVec
+}
+
+func (m *observeMetric) MetricVec() *prometheus.MetricVec {
+	return m.metricVec
 }
 
 func (m *incMetric) NeedPush() bool {

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -27,7 +27,7 @@ type Metric interface {
 	Collector() prometheus.Collector
 
 	// Returns true if the line matched, and false if the line didn't match.
-	Process(line string) (bool, bool, error)
+	Process(line string) (bool, bool, map[string]string, error)
 }
 
 // Represents a Prometheus Counter

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -38,6 +38,7 @@ type incMetric struct {
 	regex     *OnigurumaRegexp
 	labels    []templates.Template
 	collector prometheus.Collector
+	metricVec prometheus.MetricVec
 	//pushgateway related configs
 	delete_regex *OnigurumaRegexp
 	pushgateway  bool
@@ -60,6 +61,7 @@ type observeMetric struct {
 	groupingKey  []templates.Template
 
 	collector   prometheus.Collector
+	metricVec   prometheus.MetricVec
 	observeFunc func(m *OnigurumaMatchResult, val float64) error
 }
 
@@ -90,6 +92,7 @@ func NewCounterMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_regex
 			regex:        regex,
 			labels:       cfg.LabelTemplates,
 			collector:    counterVec,
+			metricVec:	  counterVec,
 			delete_regex: delete_regex,
 			pushgateway:  cfg.Pushgateway,
 			job_name:     cfg.JobName,
@@ -138,6 +141,7 @@ func NewGaugeMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_regex *
 			regex:        regex,
 			value:        cfg.ValueTemplate,
 			collector:    gaugeVec,
+			metricVec:	  gaugeVec,
 			labels:       cfg.LabelTemplates,
 			delete_regex: delete_regex,
 			pushgateway:  cfg.Pushgateway,
@@ -189,6 +193,7 @@ func NewHistogramMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_reg
 			regex:        regex,
 			value:        cfg.ValueTemplate,
 			collector:    histogramVec,
+			metricVec:    histogramVec,
 			labels:       cfg.LabelTemplates,
 			delete_regex: delete_regex,
 			pushgateway:  cfg.Pushgateway,
@@ -236,6 +241,7 @@ func NewSummaryMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_regex
 			regex:        regex,
 			value:        cfg.ValueTemplate,
 			collector:    summaryVec,
+			metricVec:    summaryVec,
 			labels:       cfg.LabelTemplates,
 			delete_regex: delete_regex,
 			pushgateway:  cfg.Pushgateway,

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -24,7 +24,7 @@ import (
 
 type Metric interface {
 	Name() string
-	Collector() prometheus.Collector
+	Collector() interface{}
 
 	// Returns true if the line matched, and false if the line didn't match.
 	Process(line string) (bool, bool, map[string]string, []string, error)
@@ -37,7 +37,7 @@ type incMetric struct {
 	name      string
 	regex     *OnigurumaRegexp
 	labels    []templates.Template
-	collector prometheus.Collector
+	collector interface{}
 
 	//pushgateway related configs
 	delete_regex *OnigurumaRegexp
@@ -60,7 +60,7 @@ type observeMetric struct {
 	job_name     string
 	groupingKey  []templates.Template
 
-	collector   prometheus.Collector
+	collector   interface{}
 	observeFunc func(m *OnigurumaMatchResult, val float64) error
 }
 

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -27,7 +27,7 @@ type Metric interface {
 	Collector() prometheus.Collector
 
 	// Returns true if the line matched, and false if the line didn't match.
-	Process(line string) (bool, bool, map[string]string, error)
+	Process(line string) (bool, bool, map[string]string, []string, error)
 	NeedPush() bool
 	JobName() string
 }

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -38,7 +38,7 @@ type incMetric struct {
 	regex     *OnigurumaRegexp
 	labels    []templates.Template
 	collector prometheus.Collector
-	metricVec *prometheus.MetricVec
+
 	//pushgateway related configs
 	delete_regex *OnigurumaRegexp
 	pushgateway  bool
@@ -61,7 +61,6 @@ type observeMetric struct {
 	groupingKey  []templates.Template
 
 	collector   prometheus.Collector
-	metricVec   *prometheus.MetricVec
 	observeFunc func(m *OnigurumaMatchResult, val float64) error
 }
 
@@ -92,7 +91,6 @@ func NewCounterMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_regex
 			regex:        regex,
 			labels:       cfg.LabelTemplates,
 			collector:    counterVec,
-			metricVec:	  counterVec,
 			delete_regex: delete_regex,
 			pushgateway:  cfg.Pushgateway,
 			job_name:     cfg.JobName,
@@ -141,7 +139,6 @@ func NewGaugeMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_regex *
 			regex:        regex,
 			value:        cfg.ValueTemplate,
 			collector:    gaugeVec,
-			metricVec:	  gaugeVec,
 			labels:       cfg.LabelTemplates,
 			delete_regex: delete_regex,
 			pushgateway:  cfg.Pushgateway,
@@ -193,7 +190,6 @@ func NewHistogramMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_reg
 			regex:        regex,
 			value:        cfg.ValueTemplate,
 			collector:    histogramVec,
-			metricVec:    histogramVec,
 			labels:       cfg.LabelTemplates,
 			delete_regex: delete_regex,
 			pushgateway:  cfg.Pushgateway,
@@ -241,7 +237,6 @@ func NewSummaryMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_regex
 			regex:        regex,
 			value:        cfg.ValueTemplate,
 			collector:    summaryVec,
-			metricVec:    summaryVec,
 			labels:       cfg.LabelTemplates,
 			delete_regex: delete_regex,
 			pushgateway:  cfg.Pushgateway,

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -339,7 +339,7 @@ func (m *observeMetric) Process(line string) (bool, bool, map[string]string, []s
 		if deleteMatch != nil && deleteMatch.IsMatch() {
 			groupingKey, err := evalGroupingKey(deleteMatch, m.groupingKey)
 			if err != nil {
-				return false, true, nil, nil, fmt.Errorf("error while getting grouping key %v: %v", m.name, e.Error())
+				return false, true, nil, nil, fmt.Errorf("error while getting grouping key %v: %v", m.name, err.Error())
 			}
 			return false, true, groupingKey, nil, nil
 		}

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -28,8 +28,8 @@ type Metric interface {
 
 	// Returns true if the line matched, and false if the line didn't match.
 	Process(line string) (bool, bool, map[string]string, error)
-	NeedPush() (bool)
-	JobName() (string)
+	NeedPush() bool
+	JobName() string
 }
 
 // Represents a Prometheus Counter

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -266,8 +266,9 @@ func (m *incMetric) Process(line string) (bool, bool, map[string]string, []strin
 		return false, false, nil, nil, fmt.Errorf("error while processing metric %v: %v", m.name, err.Error())
 	}
 	var deleteMatch *OnigurumaMatchResult = nil
+	var e error
 	if m.delete_regex != nil {
-		deleteMatch, e := m.delete_regex.Match(line)	
+		deleteMatch, e = m.delete_regex.Match(line)	
 		if e != nil {
 			return false, false, nil, nil, fmt.Errorf("error while processing metric %v: %v", m.name, e.Error())
 		}
@@ -308,8 +309,9 @@ func (m *observeMetric) Process(line string) (bool, bool, map[string]string, []s
 		return false, false, nil, nil, fmt.Errorf("error while processing metric %v: %v", m.name, err.Error())
 	}
 	var deleteMatch *OnigurumaMatchResult = nil
+	var e error
 	if m.delete_regex != nil {
-		deleteMatch, e := m.delete_regex.Match(line)	
+		deleteMatch, e = m.delete_regex.Match(line)	
 		if e != nil {
 			return false, false, nil, nil, fmt.Errorf("error while processing metric %v: %v", m.name, e.Error())
 		}

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -32,33 +32,33 @@ type Metric interface {
 
 // Represents a Prometheus Counter
 type incMetric struct {
-	name      		string
-	regex     		*OnigurumaRegexp
-	labels    		[]templates.Template
-	collector 		prometheus.Collector
+	name      string
+	regex     *OnigurumaRegexp
+	labels    []templates.Template
+	collector prometheus.Collector
 	//pushgateway related configs
-	delete_regex	*OnigurumaRegexp
-	pushgateway		bool
-	job_name		string
-	groupingKey		[]templates.Template
+	delete_regex *OnigurumaRegexp
+	pushgateway  bool
+	job_name     string
+	groupingKey  []templates.Template
 
-	incFunc   		func(m *OnigurumaMatchResult) error
+	incFunc func(m *OnigurumaMatchResult) error
 }
 
 // Represents a Prometheus Gauge, Histogram, or Summary
 type observeMetric struct {
-	name        	string
-	regex      		*OnigurumaRegexp
-	value       	templates.Template
-	labels      	[]templates.Template
+	name   string
+	regex  *OnigurumaRegexp
+	value  templates.Template
+	labels []templates.Template
 	//pushgateway related configs
-	delete_regex	*OnigurumaRegexp
-	pushgateway		bool
-	job_name		string
-	groupingKey		[]templates.Template
+	delete_regex *OnigurumaRegexp
+	pushgateway  bool
+	job_name     string
+	groupingKey  []templates.Template
 
-	collector   	prometheus.Collector
-	observeFunc 	func(m *OnigurumaMatchResult, val float64) error
+	collector   prometheus.Collector
+	observeFunc func(m *OnigurumaMatchResult, val float64) error
 }
 
 func NewCounterMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_regex *OnigurumaRegexp) Metric {
@@ -69,13 +69,13 @@ func NewCounterMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_regex
 	if len(cfg.Labels) == 0 { // regular counter
 		counter := prometheus.NewCounter(counterOpts)
 		return &incMetric{
-			name:      cfg.Name,
-			regex:     regex,
-			collector: counter,
-			delete_regex:	delete_regex,
-			pushgateway:	cfg.Pushgateway,
-			job_name: 		cfg.JobName,
-			groupingKey:	cfg.GroupTemplates,
+			name:         cfg.Name,
+			regex:        regex,
+			collector:    counter,
+			delete_regex: delete_regex,
+			pushgateway:  cfg.Pushgateway,
+			job_name:     cfg.JobName,
+			groupingKey:  cfg.GroupTemplates,
 			incFunc: func(_ *OnigurumaMatchResult) error {
 				counter.Inc()
 				return nil
@@ -84,14 +84,14 @@ func NewCounterMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_regex
 	} else { // counterVec
 		counterVec := prometheus.NewCounterVec(counterOpts, prometheusLabels(cfg.LabelTemplates))
 		result := &incMetric{
-			name:      cfg.Name,
-			regex:     regex,
-			labels:    cfg.LabelTemplates,
-			collector: counterVec,
-			delete_regex:	delete_regex,
-			pushgateway:	cfg.Pushgateway,
-			job_name: 		cfg.JobName,
-			groupingKey:	cfg.GroupTemplates,
+			name:         cfg.Name,
+			regex:        regex,
+			labels:       cfg.LabelTemplates,
+			collector:    counterVec,
+			delete_regex: delete_regex,
+			pushgateway:  cfg.Pushgateway,
+			job_name:     cfg.JobName,
+			groupingKey:  cfg.GroupTemplates,
 			incFunc: func(m *OnigurumaMatchResult) error {
 				vals, err := labelValues(m, cfg.LabelTemplates)
 				if err == nil {
@@ -112,14 +112,14 @@ func NewGaugeMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_regex *
 	if len(cfg.Labels) == 0 { // regular gauge
 		gauge := prometheus.NewGauge(gaugeOpts)
 		return &observeMetric{
-			name:      cfg.Name,
-			regex:     regex,
-			value:     cfg.ValueTemplate,
-			collector: gauge,
-			delete_regex:	delete_regex,
-			pushgateway:	cfg.Pushgateway,
-			job_name: 		cfg.JobName,
-			groupingKey:	cfg.GroupTemplates,
+			name:         cfg.Name,
+			regex:        regex,
+			value:        cfg.ValueTemplate,
+			collector:    gauge,
+			delete_regex: delete_regex,
+			pushgateway:  cfg.Pushgateway,
+			job_name:     cfg.JobName,
+			groupingKey:  cfg.GroupTemplates,
 			observeFunc: func(_ *OnigurumaMatchResult, val float64) error {
 				if cfg.Cumulative {
 					gauge.Add(val)
@@ -132,15 +132,15 @@ func NewGaugeMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_regex *
 	} else { // gaugeVec
 		gaugeVec := prometheus.NewGaugeVec(gaugeOpts, prometheusLabels(cfg.LabelTemplates))
 		return &observeMetric{
-			name:      cfg.Name,
-			regex:     regex,
-			value:     cfg.ValueTemplate,
-			collector: gaugeVec,
-			labels:    cfg.LabelTemplates,
-			delete_regex:	delete_regex,
-			pushgateway:	cfg.Pushgateway,
-			job_name: 		cfg.JobName,
-			groupingKey:	cfg.GroupTemplates,
+			name:         cfg.Name,
+			regex:        regex,
+			value:        cfg.ValueTemplate,
+			collector:    gaugeVec,
+			labels:       cfg.LabelTemplates,
+			delete_regex: delete_regex,
+			pushgateway:  cfg.Pushgateway,
+			job_name:     cfg.JobName,
+			groupingKey:  cfg.GroupTemplates,
 			observeFunc: func(m *OnigurumaMatchResult, val float64) error {
 				vals, err := labelValues(m, cfg.LabelTemplates)
 				if err == nil {
@@ -167,14 +167,14 @@ func NewHistogramMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_reg
 	if len(cfg.Labels) == 0 { // regular histogram
 		histogram := prometheus.NewHistogram(histogramOpts)
 		return &observeMetric{
-			name:      cfg.Name,
-			regex:     regex,
-			value:     cfg.ValueTemplate,
-			collector: histogram,
-			delete_regex:	delete_regex,
-			pushgateway:	cfg.Pushgateway,
-			job_name: 		cfg.JobName,
-			groupingKey:	cfg.GroupTemplates,
+			name:         cfg.Name,
+			regex:        regex,
+			value:        cfg.ValueTemplate,
+			collector:    histogram,
+			delete_regex: delete_regex,
+			pushgateway:  cfg.Pushgateway,
+			job_name:     cfg.JobName,
+			groupingKey:  cfg.GroupTemplates,
 			observeFunc: func(_ *OnigurumaMatchResult, val float64) error {
 				histogram.Observe(val)
 				return nil
@@ -183,15 +183,15 @@ func NewHistogramMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_reg
 	} else { // histogramVec
 		histogramVec := prometheus.NewHistogramVec(histogramOpts, prometheusLabels(cfg.LabelTemplates))
 		return &observeMetric{
-			name:      cfg.Name,
-			regex:     regex,
-			value:     cfg.ValueTemplate,
-			collector: histogramVec,
-			labels:    cfg.LabelTemplates,
-			delete_regex:	delete_regex,
-			pushgateway:	cfg.Pushgateway,
-			job_name: 		cfg.JobName,
-			groupingKey:	cfg.GroupTemplates,
+			name:         cfg.Name,
+			regex:        regex,
+			value:        cfg.ValueTemplate,
+			collector:    histogramVec,
+			labels:       cfg.LabelTemplates,
+			delete_regex: delete_regex,
+			pushgateway:  cfg.Pushgateway,
+			job_name:     cfg.JobName,
+			groupingKey:  cfg.GroupTemplates,
 			observeFunc: func(m *OnigurumaMatchResult, val float64) error {
 				vals, err := labelValues(m, cfg.LabelTemplates)
 				if err == nil {
@@ -214,14 +214,14 @@ func NewSummaryMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_regex
 	if len(cfg.Labels) == 0 { // regular summary
 		summary := prometheus.NewSummary(summaryOpts)
 		return &observeMetric{
-			name:      cfg.Name,
-			regex:     regex,
-			value:     cfg.ValueTemplate,
-			collector: summary,
-			delete_regex:	delete_regex,
-			pushgateway:	cfg.Pushgateway,
-			job_name: 		cfg.JobName,
-			groupingKey:	cfg.GroupTemplates,
+			name:         cfg.Name,
+			regex:        regex,
+			value:        cfg.ValueTemplate,
+			collector:    summary,
+			delete_regex: delete_regex,
+			pushgateway:  cfg.Pushgateway,
+			job_name:     cfg.JobName,
+			groupingKey:  cfg.GroupTemplates,
 			observeFunc: func(_ *OnigurumaMatchResult, val float64) error {
 				summary.Observe(val)
 				return nil
@@ -230,15 +230,15 @@ func NewSummaryMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_regex
 	} else { // summaryVec
 		summaryVec := prometheus.NewSummaryVec(summaryOpts, prometheusLabels(cfg.LabelTemplates))
 		return &observeMetric{
-			name:      cfg.Name,
-			regex:     regex,
-			value:     cfg.ValueTemplate,
-			collector: summaryVec,
-			labels:    cfg.LabelTemplates,
-			delete_regex:	delete_regex,
-			pushgateway:	cfg.Pushgateway,
-			job_name: 		cfg.JobName,
-			groupingKey:	cfg.GroupTemplates,
+			name:         cfg.Name,
+			regex:        regex,
+			value:        cfg.ValueTemplate,
+			collector:    summaryVec,
+			labels:       cfg.LabelTemplates,
+			delete_regex: delete_regex,
+			pushgateway:  cfg.Pushgateway,
+			job_name:     cfg.JobName,
+			groupingKey:  cfg.GroupTemplates,
 			observeFunc: func(m *OnigurumaMatchResult, val float64) error {
 				vals, err := labelValues(m, cfg.LabelTemplates)
 				if err == nil {
@@ -254,11 +254,11 @@ func NewSummaryMetric(cfg *v2.MetricConfig, regex *OnigurumaRegexp, delete_regex
 func (m *incMetric) Process(line string) (bool, bool, map[string]string, error) {
 	matchResult, err := m.regex.Match(line)
 	deleteMatch, e := m.delete_regex.Match(line)
-	if err != nil  {
+	if err != nil {
 		return false, false, nil, fmt.Errorf("error while processing metric %v: %v", m.name, err.Error())
 	}
 	if e != nil {
-		return false, false, nil, fmt.Errorf("error while processing metric %v: %v", m.name, e.Error())	
+		return false, false, nil, fmt.Errorf("error while processing metric %v: %v", m.name, e.Error())
 	}
 
 	defer matchResult.Free()
@@ -267,12 +267,12 @@ func (m *incMetric) Process(line string) (bool, bool, map[string]string, error) 
 	deleteMatched := deleteMatch.IsMatch()
 	if matchResult.IsMatch() {
 		err = m.incFunc(matchResult)
-		groupingKey, e:= evalGroupingKey(matchResult, m.groupingKey)
+		groupingKey, e := evalGroupingKey(matchResult, m.groupingKey)
 		if e != nil {
 			return true, deleteMatched, nil, fmt.Errorf("error while getting grouping key %v: %v", m.name, e.Error())
 		}
 		return true, deleteMatched, groupingKey, err
-		
+
 	} else {
 		return false, deleteMatched, nil, nil
 	}

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -39,7 +39,7 @@ type incMetric struct {
 	regex     *OnigurumaRegexp
 	labels    []templates.Template
 	collector prometheus.Collector
-    metricVec *prometheus.MetricVec
+	metricVec *prometheus.MetricVec
 	//pushgateway related configs
 	delete_regex *OnigurumaRegexp
 	pushgateway  bool
@@ -268,7 +268,7 @@ func (m *incMetric) Process(line string) (bool, bool, map[string]string, []strin
 	var deleteMatch *OnigurumaMatchResult = nil
 	var e error
 	if m.delete_regex != nil {
-		deleteMatch, e = m.delete_regex.Match(line)	
+		deleteMatch, e = m.delete_regex.Match(line)
 		if e != nil {
 			return false, false, nil, nil, fmt.Errorf("error while processing metric %v: %v", m.name, e.Error())
 		}
@@ -276,9 +276,8 @@ func (m *incMetric) Process(line string) (bool, bool, map[string]string, []strin
 
 	defer matchResult.Free()
 	if deleteMatch != nil {
-		defer deleteMatch.Free()	
+		defer deleteMatch.Free()
 	}
-	
 
 	//metric can either be pushed or deleted, CANNOT be both in single line processing
 	if matchResult.IsMatch() {
@@ -311,14 +310,14 @@ func (m *observeMetric) Process(line string) (bool, bool, map[string]string, []s
 	var deleteMatch *OnigurumaMatchResult = nil
 	var e error
 	if m.delete_regex != nil {
-		deleteMatch, e = m.delete_regex.Match(line)	
+		deleteMatch, e = m.delete_regex.Match(line)
 		if e != nil {
 			return false, false, nil, nil, fmt.Errorf("error while processing metric %v: %v", m.name, e.Error())
 		}
 	}
 	defer matchResult.Free()
 	if deleteMatch != nil {
-		defer deleteMatch.Free()	
+		defer deleteMatch.Free()
 	}
 
 	if matchResult.IsMatch() {

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -176,10 +176,14 @@ func doRequest(job string, groupingKey map[string]string, targetUrl string, g pr
 		}
 	}
 
+	var request *Request
 	if method == "DELETE" {
-		buf = nil
+		request, err := http.NewRequest(method, targetUrl, nil)	
 	}
-	request, err := http.NewRequest(method, targetUrl, buf)
+	else {
+		request, err := http.NewRequest(method, targetUrl, buf)
+	}
+	
 	if err != nil {
 		return err
 	}

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -137,19 +137,13 @@ func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string
 		return err
 	}
 	//remove metric from collector
-	deleted := false
-	if m.metricVec != nil {
-		deleted = m.metricVec.DeleteLabelValues(labelValues...)
-	}
+	deleted := m.Collector().DeleteLabelValues(labelValues...)
 
 	if deleted {
 		fmt.Println(fmt.Sprintf("[DEBUG] Deleted metric %s from collector %s.", m.Name(), m.Collector()))
 	} else {
-		if m.metricVec == nil {
-			fmt.Println("[DEBUG] Detected metric instead of metric vector.")	
-		} else {
-			fmt.Println(fmt.Sprintf("[DEBUG] Failed to delete metric %s from collector %s.", m.Name(), m.Collector()))	
-		}
+		fmt.Println(fmt.Sprintf("[DEBUG] Failed to delete metric %s from collector %s.", m.Name(), m.Collector()))	
+	
 	}
 	return nil
 }

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -179,8 +179,7 @@ func doRequest(job string, groupingKey map[string]string, targetUrl string, g pr
 	var request *Request
 	if method == "DELETE" {
 		request, err := http.NewRequest(method, targetUrl, nil)	
-	}
-	else {
+	} else {
 		request, err := http.NewRequest(method, targetUrl, buf)
 	}
 	

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -21,14 +21,14 @@ import (
 	"github.com/fstab/grok_exporter/config/v2"
 	"github.com/fstab/grok_exporter/exporter"
 	"github.com/fstab/grok_exporter/tailer"
-	"github.com/prometheus/common/expfmt"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
-	"strings"
-	"net/url"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -87,7 +87,7 @@ func main() {
 			for _, metric := range metrics {
 				start := time.Now()
 				match, delete_match, groupingKey, err := metric.Process(line)
-				
+
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "WARNING: Skipping log line: %v\n", err.Error())
 					fmt.Fprintf(os.Stderr, "%v\n", line)
@@ -127,11 +127,11 @@ func pushMetric(m exporter.Metric, url string, groupingKey map[string]string) er
 }
 
 func deleteMetric(m exporter.Metric, url string, groupingKey map[string]string) error {
-	if (!strings.Contains(url, "://")) {
+	if !strings.Contains(url, "://") {
 		url = "http://" + url
 	}
 	if strings.HasSuffix(url, "/") {
-		url = url[:len(url) - 1]
+		url = url[:len(url)-1]
 	}
 
 	if strings.Contains(m.getJobName(), "/") {
@@ -249,7 +249,6 @@ func createMetrics(cfg *v2.Config, patterns *exporter.Patterns, libonig *exporte
 			return nil, fmt.Errorf("Failed to initialize metrics: Metric type %v is not supported.", m.Type)
 		}
 
-	
 	}
 	return result, nil
 }

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -137,11 +137,19 @@ func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string
 		return err
 	}
 	//remove metric from collector
-	deleted := *prometheus.MetricVec(m.Collector()).DeleteLabelValues(labelValues...)
+	deleted := false
+	if m.metricVec != nil {
+		deleted = m.metricVec.DeleteLabelValues(labelValues...)
+	}
+
 	if deleted {
 		fmt.Println(fmt.Sprintf("[DEBUG] Deleted metric %s from collector %s.", m.Name(), m.Collector()))
 	} else {
-		fmt.Println(fmt.Sprintf("[DEBUG] Failed to delete metric %s from collector %s.", m.Name(), m.Collector()))
+		if m.metricVec == nil {
+			fmt.Println("[DEBUG] Detected metric instead of metric vector.")	
+		} else {
+			fmt.Println(fmt.Sprintf("[DEBUG] Failed to delete metric %s from collector %s.", m.Name(), m.Collector()))	
+		}
 	}
 	return nil
 }

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -128,7 +128,7 @@ func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string
 }
 
 func deleteMetric(m exporter.Metric, deleteUrl string, groupingKey map[string]string) error {
-	fmt.Println(fmt.Sprintf("Deleting metric %s with labels %s from pushgateway %s", m.Name(), groupingKey, pushUrl))
+	fmt.Println(fmt.Sprintf("Deleting metric %s with labels %s from pushgateway %s", m.Name(), groupingKey, deleteUrl))
 	if !strings.Contains(deleteUrl, "://") {
 		deleteUrl = "http://" + deleteUrl
 	}

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -162,7 +162,7 @@ func doRequest(job string, groupingKey map[string]string, targetUrl string, g pr
 
 	targetUrl = fmt.Sprintf("%s/metrics/job/%s", targetUrl, strings.Join(urlComponents, "/"))
 
-	buf := &bytes.Buffer()
+	buf := &bytes.Buffer{}
 	enc := expfmt.NewEncoder(buf, expfmt.FmtProtoDelim)
 	if g != nil {
 		mfs, err := g.Gather()

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -122,13 +122,13 @@ func main() {
 }
 
 func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string) error {
-	fmt.Println(fmt.Sprintf("Pushing metric %s with labels %s to pushgateway %s", m.Name(), groupingKey, pushUrl))
+	fmt.Println(fmt.Sprintf("Pushing metric %s with labels %s to pushgateway %s of job %s", m.Name(), groupingKey, pushUrl, m.JobName()))
 	err := push.Collectors(m.JobName(), groupingKey, pushUrl, m.Collector())
 	return err
 }
 
 func deleteMetric(m exporter.Metric, deleteUrl string, groupingKey map[string]string) error {
-	fmt.Println(fmt.Sprintf("Deleting metric %s with labels %s from pushgateway %s", m.Name(), groupingKey, deleteUrl))
+	fmt.Println(fmt.Sprintf("Deleting metric %s with labels %s from pushgateway %s of job %s", m.Name(), groupingKey, deleteUrl, m.JobName()))
 	if !strings.Contains(deleteUrl, "://") {
 		deleteUrl = "http://" + deleteUrl
 	}

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -149,7 +149,7 @@ func doRequest(job string, groupingKey map[string]string, targetUrl string, g pr
 	if strings.Contains(job, "/") {
 		return fmt.Errorf("job contains '/' : %s", job)
 	}
-	urlComponents := []string{url.QueryEscape(job}
+	urlComponents := []string{url.QueryEscape(job)
 	for ln, lv := range groupingKey {
 		if !model.LabelName(ln).IsValid() {
 			return fmt.Errorf("groupingKey label has invalid name: %s", ln)

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -98,7 +98,8 @@ func main() {
 					if metric.NeedPush() {
 						err := pushMetric(metric, cfg.Global.PushgatewayAddr, groupingKey)
 						if err != nil {
-							fmt.Println(fmt.Errorf("Error pushing metric %v to pushgateway.", metric.Name()))
+							fmt.Println(fmt.Sprintf("Push error: %s",err))
+							fmt.Errorf("Error pushing metric %v to pushgateway.", metric.Name())
 						}
 					}
 

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -226,8 +226,7 @@ func createMetrics(cfg *v2.Config, patterns *exporter.Patterns, libonig *exporte
 			return nil, fmt.Errorf("failed to initialize metric %v: %v", m.Name, err.Error())
 		}
 
-		var delete_regex *OnigurumaRegexp
-		delete_regex, err = exporter.Compile(m.DeleteMatch, patterns, libonig)
+		delete_regex, err := exporter.Compile(m.DeleteMatch, patterns, libonig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize metric %v: %v", m.Name, err.Error())
 		}

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -281,8 +281,9 @@ func createMetrics(cfg *v2.Config, patterns *exporter.Patterns, libonig *exporte
 		}
 
 		var delete_regex *exporter.OnigurumaRegexp = nil
+		var err error
 		if len(m.DeleteMatch) != 0 {
-			delete_regex, err := exporter.Compile(m.DeleteMatch, patterns, libonig)
+			delete_regex, err = exporter.Compile(m.DeleteMatch, patterns, libonig)
 			if err != nil {
 				return nil, fmt.Errorf("failed to initialize metric %v: %v", m.Name, err.Error())
 			}

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -124,8 +124,7 @@ func main() {
 
 func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string) error {
 	fmt.Println(fmt.Sprintf("Pushing metric %s with labels %s to pushgateway %s of job %s", m.Name(), groupingKey, pushUrl, m.JobName()))
-	//err := push.AddCollectors(m.JobName(), groupingKey, pushUrl, m.Collector())
-	err := push.AddCollectors(m.JobName(), map[string]string{"user":"alice"}, pushUrl, m.Collector())
+	err := push.AddCollectors(m.JobName(), groupingKey, pushUrl, m.Collector())
 	return err
 }
 

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -122,11 +122,13 @@ func main() {
 }
 
 func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string) error {
+	fmt.Printf("Pushing metric %s to pushgateway %s", m.Name(), pushUrl)
 	err := push.Collectors(m.JobName(), groupingKey, pushUrl, m.Collector())
 	return err
 }
 
 func deleteMetric(m exporter.Metric, deleteUrl string, groupingKey map[string]string) error {
+	fmt.Printf("Deleting metric %s from pushgateway %s", m.Name(), deleteUrl)
 	if !strings.Contains(deleteUrl, "://") {
 		deleteUrl = "http://" + deleteUrl
 	}

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -87,7 +87,8 @@ func main() {
 			for _, metric := range metrics {
 				start := time.Now()
 				match, delete_match, groupingKey, err := metric.Process(line)
-
+				fmt.Println(fmt.Sprintf("Process result: match: %s, delete_match: %s, groupingKey: %s, err: %s", match, delete_match, groupingKey, err))
+				
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "WARNING: Skipping log line: %v\n", err.Error())
 					fmt.Fprintf(os.Stderr, "%v\n", line)
@@ -152,7 +153,7 @@ func deleteMetric(m exporter.Metric, deleteUrl string, groupingKey map[string]st
 
 	deleteUrl = fmt.Sprintf("%s/metrics/job/%s", deleteUrl, strings.Join(urlComponents, "/"))
 	fmt.Println(deleteUrl)
-	
+
 	request, err := http.NewRequest("DELETE", deleteUrl, nil)
 	if err != nil {
 		return err

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -149,7 +149,7 @@ func doRequest(job string, groupingKey map[string]string, targetUrl string, g pr
 	if strings.Contains(job, "/") {
 		return fmt.Errorf("job contains '/' : %s", job)
 	}
-	urlComponents := []string{url.QueryEscape(job)
+	urlComponents := []string{url.QueryEscape(job)}
 	for ln, lv := range groupingKey {
 		if !model.LabelName(ln).IsValid() {
 			return fmt.Errorf("groupingKey label has invalid name: %s", ln)

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -136,9 +136,9 @@ func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string
 	}
 	//remove metric from registry
 	if r.Unregister(m.Collector()) {
-		fmt.Println(fmt.Sprintf("[DEBUG] Unregister collector %s from registry.", m.Collector())
+		fmt.Println(fmt.Sprintf("[DEBUG] Unregister collector %s from registry.", m.Collector()))
 	} else {
-		fmt.Println(fmt.Sprintf("[DEBUG] Failed to unregister collector %s from registry.", m.Collector())
+		fmt.Println(fmt.Sprintf("[DEBUG] Failed to unregister collector %s from registry.", m.Collector()))
 	}
 	return nil
 }

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -139,9 +139,9 @@ func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string
 	//remove metric from collector
 	deleted := m.Collector().DeleteLabelValues(labelValues...)
 	if deleted {
-		fmt.Println(fmt.Sprintf("[DEBUG] Deleted metric %s from collector %s.", m.Name(), m.Collector())
+		fmt.Println(fmt.Sprintf("[DEBUG] Deleted metric %s from collector %s.", m.Name(), m.Collector()))
 	} else {
-		fmt.Println(fmt.Sprintf("[DEBUG] Failed to delete metric %s from collector %s.", m.Name(), m.Collector())
+		fmt.Println(fmt.Sprintf("[DEBUG] Failed to delete metric %s from collector %s.", m.Name(), m.Collector()))
 	}
 	return nil
 }

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -148,8 +148,8 @@ func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string
 		if m.MetricVec() == nil {
 			fmt.Println("[DEBUG] Detected metric instead of metric vector.")
 		}
-		fmt.Println(fmt.Sprintf("[DEBUG] Failed to delete metric %s from collector %s.", m.Name(), m.Collector()))	
-	
+		fmt.Println(fmt.Sprintf("[DEBUG] Failed to delete metric %s from collector %s.", m.Name(), m.Collector()))
+
 	}
 	return nil
 }
@@ -281,7 +281,7 @@ func createMetrics(cfg *v2.Config, patterns *exporter.Patterns, libonig *exporte
 		}
 
 		var delete_regex *exporter.OnigurumaRegexp = nil
-		
+
 		if len(m.DeleteMatch) != 0 {
 			delete_regex, err = exporter.Compile(m.DeleteMatch, patterns, libonig)
 			if err != nil {
@@ -292,7 +292,6 @@ func createMetrics(cfg *v2.Config, patterns *exporter.Patterns, libonig *exporte
 				return nil, fmt.Errorf("failed to initialize metric %v: %v", m.Name, err.Error())
 			}
 		}
-		
 
 		switch m.Type {
 		case "counter":

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -88,7 +88,7 @@ func main() {
 				start := time.Now()
 				match, delete_match, groupingKey, err := metric.Process(line)
 				fmt.Println(fmt.Sprintf("Process result: match: %s, delete_match: %s, groupingKey: %s, err: %s", match, delete_match, groupingKey, err))
-				
+
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "WARNING: Skipping log line: %v\n", err.Error())
 					fmt.Fprintf(os.Stderr, "%v\n", line)
@@ -124,7 +124,8 @@ func main() {
 
 func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string) error {
 	fmt.Println(fmt.Sprintf("Pushing metric %s with labels %s to pushgateway %s of job %s", m.Name(), groupingKey, pushUrl, m.JobName()))
-	err := push.AddCollectors(m.JobName(), groupingKey, pushUrl, m.Collector())
+	//err := push.AddCollectors(m.JobName(), groupingKey, pushUrl, m.Collector())
+	err := push.AddCollectors(m.JobName(), map[string]string{"user":"alice"}, pushUrl, m.Collector())
 	return err
 }
 

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -22,7 +22,7 @@ import (
 	"github.com/fstab/grok_exporter/exporter"
 	"github.com/fstab/grok_exporter/tailer"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/push"
+	//"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
 	"net/http"
@@ -138,7 +138,7 @@ func deleteMetric(m exporter.Metric, deleteUrl string, groupingKey map[string]st
 	
 }
 
-func doRequest(job string, targetUrl string, groupingKey map[string]string, g prometheus.Gatherer, method string) error {
+func doRequest(job string, groupingKey map[string]string, targetUrl string, g prometheus.Gatherer, method string) error {
 	if !strings.Contains(targetUrl, "://") {
 		targetUrl = "http://" + targetUrl
 	}
@@ -146,10 +146,10 @@ func doRequest(job string, targetUrl string, groupingKey map[string]string, g pr
 		targetUrl = targetUrl[:len(targetUrl)-1]
 	}
 
-	if strings.Contains(m.JobName(), "/") {
-		return fmt.Errorf("job contains '/' : %s", m.JobName())
+	if strings.Contains(job, "/") {
+		return fmt.Errorf("job contains '/' : %s", job)
 	}
-	urlComponents := []string{url.QueryEscape(m.JobName())}
+	urlComponents := []string{url.QueryEscape(job}
 	for ln, lv := range groupingKey {
 		if !model.LabelName(ln).IsValid() {
 			return fmt.Errorf("groupingKey label has invalid name: %s", ln)

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -87,6 +87,7 @@ func main() {
 			for _, metric := range metrics {
 				start := time.Now()
 				match, delete_match, groupingKey, err := metric.Process(line)
+				fmt.Printf("processing result: %s %s %s %s", match, delete_match, groupingKey, err)
 
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "WARNING: Skipping log line: %v\n", err.Error())

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -15,9 +15,9 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
-	"bytes"
 	"github.com/fstab/grok_exporter/config"
 	"github.com/fstab/grok_exporter/config/v2"
 	"github.com/fstab/grok_exporter/exporter"
@@ -99,7 +99,7 @@ func main() {
 					if metric.NeedPush() {
 						err := pushMetric(metric, cfg.Global.PushgatewayAddr, groupingKey)
 						if err != nil {
-							fmt.Println(fmt.Sprintf("[DEBUG] Push error: %s",err))
+							fmt.Println(fmt.Sprintf("[DEBUG] Push error: %s", err))
 							fmt.Errorf("Error pushing metric %v to pushgateway.", metric.Name())
 						}
 					}
@@ -136,7 +136,7 @@ func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string
 func deleteMetric(m exporter.Metric, deleteUrl string, groupingKey map[string]string) error {
 	fmt.Println(fmt.Sprintf("[DEBUG] Deleting metric %s with labels %s from pushgateway %s of job %s", m.Name(), groupingKey, deleteUrl, m.JobName()))
 	return doRequest(m.JobName(), groupingKey, deleteUrl, nil, "DELETE")
-	
+
 }
 
 func doRequest(job string, groupingKey map[string]string, targetUrl string, g prometheus.Gatherer, method string) error {
@@ -179,11 +179,11 @@ func doRequest(job string, groupingKey map[string]string, targetUrl string, g pr
 	var request *http.Request
 	var err error
 	if method == "DELETE" {
-		request, err = http.NewRequest(method, targetUrl, nil)	
+		request, err = http.NewRequest(method, targetUrl, nil)
 	} else {
 		request, err = http.NewRequest(method, targetUrl, buf)
 	}
-	
+
 	if err != nil {
 		return err
 	}

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -137,11 +137,17 @@ func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string
 		return err
 	}
 	//remove metric from collector
-	deleted := m.Collector().DeleteLabelValues(labelValues...)
+	deleted := false
+	if m.metricVec != nil {
+		deleted = m.metricVec.DeleteLabelValues(labelValues...)
+	}
 
 	if deleted {
 		fmt.Println(fmt.Sprintf("[DEBUG] Deleted metric %s from collector %s.", m.Name(), m.Collector()))
 	} else {
+		if m.metricVec == nil {
+			fmt.Println("[DEBUG] Detected metric instead of metric vector.")
+		}
 		fmt.Println(fmt.Sprintf("[DEBUG] Failed to delete metric %s from collector %s.", m.Name(), m.Collector()))	
 	
 	}

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -137,7 +137,7 @@ func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string
 		return err
 	}
 	//remove metric from collector
-	deleted := m.Collector().DeleteLabelValues(labelValues...)
+	deleted := *prometheus.MetricVec(m.Collector()).DeleteLabelValues(labelValues...)
 	if deleted {
 		fmt.Println(fmt.Sprintf("[DEBUG] Deleted metric %s from collector %s.", m.Name(), m.Collector()))
 	} else {

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -138,8 +138,8 @@ func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string
 	}
 	//remove metric from collector
 	deleted := false
-	if m.metricVec != nil {
-		deleted = m.metricVec.DeleteLabelValues(labelValues...)
+	if m.MetricVec() != nil {
+		deleted = m.MetricVec().DeleteLabelValues(labelValues...)
 	}
 
 	if deleted {

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -130,7 +130,13 @@ func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string
 	if err := r.Register(m.Collector()); err != nil {
 		return err
 	}
-	return doRequest(m.JobName(), groupingKey, pushUrl, r, "POST")
+	err := doRequest(m.JobName(), groupingKey, pushUrl, r, "POST")
+	if err != nil {
+		return err
+	}
+	//remove metric from registry
+	r.Unregister(m.Collector())
+	return nil
 }
 
 func deleteMetric(m exporter.Metric, deleteUrl string, groupingKey map[string]string) error {

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -280,14 +280,18 @@ func createMetrics(cfg *v2.Config, patterns *exporter.Patterns, libonig *exporte
 			return nil, fmt.Errorf("failed to initialize metric %v: %v", m.Name, err.Error())
 		}
 
-		delete_regex, err := exporter.Compile(m.DeleteMatch, patterns, libonig)
-		if err != nil {
-			return nil, fmt.Errorf("failed to initialize metric %v: %v", m.Name, err.Error())
+		var delete_regex *OnigurumaRegexp = nil
+		if m.DeleteMatch != nil {
+			delete_regex, err := exporter.Compile(m.DeleteMatch, patterns, libonig)
+			if err != nil {
+				return nil, fmt.Errorf("failed to initialize metric %v: %v", m.Name, err.Error())
+			}
+			err = exporter.VerifyGroupingKeyField(m, delete_regex)
+			if err != nil {
+				return nil, fmt.Errorf("failed to initialize metric %v: %v", m.Name, err.Error())
+			}
 		}
-		err = exporter.VerifyGroupingKeyField(m, delete_regex)
-		if err != nil {
-			return nil, fmt.Errorf("failed to initialize metric %v: %v", m.Name, err.Error())
-		}
+		
 
 		switch m.Type {
 		case "counter":

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -123,7 +123,7 @@ func main() {
 
 func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string) error {
 	fmt.Println(fmt.Sprintf("Pushing metric %s with labels %s to pushgateway %s of job %s", m.Name(), groupingKey, pushUrl, m.JobName()))
-	err := push.Collectors(m.JobName(), groupingKey, pushUrl, m.Collector())
+	err := push.AddCollectors(m.JobName(), groupingKey, pushUrl, m.Collector())
 	return err
 }
 

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -263,7 +263,7 @@ func createMetrics(cfg *v2.Config, patterns *exporter.Patterns, libonig *exporte
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize metric %v: %v", m.Name, err.Error())
 		}
-		err = exporter.VerifyFieldNames(m, delete_regex)
+		err = exporter.VerifyGroupingKeyField(m, delete_regex)
 		if err != nil {
 			return nil, fmt.Errorf("failed to initialize metric %v: %v", m.Name, err.Error())
 		}

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -281,7 +281,7 @@ func createMetrics(cfg *v2.Config, patterns *exporter.Patterns, libonig *exporte
 		}
 
 		var delete_regex *exporter.OnigurumaRegexp = nil
-		var err error
+		
 		if len(m.DeleteMatch) != 0 {
 			delete_regex, err = exporter.Compile(m.DeleteMatch, patterns, libonig)
 			if err != nil {

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -17,6 +17,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"bytes"
 	"github.com/fstab/grok_exporter/config"
 	"github.com/fstab/grok_exporter/config/v2"
 	"github.com/fstab/grok_exporter/exporter"

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -176,7 +176,8 @@ func doRequest(job string, groupingKey map[string]string, targetUrl string, g pr
 		}
 	}
 
-	var request *Request
+	var request *http.Request
+	var err error
 	if method == "DELETE" {
 		request, err := http.NewRequest(method, targetUrl, nil)	
 	} else {

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -280,8 +280,8 @@ func createMetrics(cfg *v2.Config, patterns *exporter.Patterns, libonig *exporte
 			return nil, fmt.Errorf("failed to initialize metric %v: %v", m.Name, err.Error())
 		}
 
-		var delete_regex *OnigurumaRegexp = nil
-		if m.DeleteMatch != nil {
+		var delete_regex *exporter.OnigurumaRegexp = nil
+		if len(m.DeleteMatch) != 0 {
 			delete_regex, err := exporter.Compile(m.DeleteMatch, patterns, libonig)
 			if err != nil {
 				return nil, fmt.Errorf("failed to initialize metric %v: %v", m.Name, err.Error())

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -97,6 +97,7 @@ func main() {
 				if match {
 					if metric.NeedPush() {
 						err := pushMetric(metric, cfg.Global.PushgatewayAddr, groupingKey)
+						fmt.Println("%s", err)
 						if err != nil {
 							fmt.Errorf("Error pushing metric %v to pushgateway.", metric.Name())
 						}

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -73,7 +73,7 @@ func main() {
 
 	tail, err := startTailer(cfg)
 	exitOnError(err)
-	fmt.Print(startMsg(cfg))
+	fmt.Println(startMsg(cfg))
 	serverErrors := startServer(cfg, "/metrics", prometheus.Handler())
 
 	for {
@@ -122,13 +122,13 @@ func main() {
 }
 
 func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string) error {
-	fmt.Printf("Pushing metric %s to pushgateway %s", m.Name(), pushUrl)
+	fmt.Println(fmt.Sprintf("Pushing metric %s to pushgateway %s", m.Name(), pushUrl))
 	err := push.Collectors(m.JobName(), groupingKey, pushUrl, m.Collector())
 	return err
 }
 
 func deleteMetric(m exporter.Metric, deleteUrl string, groupingKey map[string]string) error {
-	fmt.Printf("Deleting metric %s from pushgateway %s", m.Name(), deleteUrl)
+	fmt.Println(fmt.Sprintf("Deleting metric %s from pushgateway %s", m.Name(), deleteUrl))
 	if !strings.Contains(deleteUrl, "://") {
 		deleteUrl = "http://" + deleteUrl
 	}

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -87,7 +87,6 @@ func main() {
 			for _, metric := range metrics {
 				start := time.Now()
 				match, delete_match, groupingKey, err := metric.Process(line)
-				fmt.Printf("processing result: %s %s %s %s", match, delete_match, groupingKey, err)
 
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "WARNING: Skipping log line: %v\n", err.Error())
@@ -123,13 +122,13 @@ func main() {
 }
 
 func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string) error {
-	fmt.Println(fmt.Sprintf("Pushing metric %s to pushgateway %s", m.Name(), pushUrl))
+	fmt.Println(fmt.Sprintf("Pushing metric %s with labels %s to pushgateway %s", m.Name(), groupingKey, pushUrl))
 	err := push.Collectors(m.JobName(), groupingKey, pushUrl, m.Collector())
 	return err
 }
 
 func deleteMetric(m exporter.Metric, deleteUrl string, groupingKey map[string]string) error {
-	fmt.Println(fmt.Sprintf("Deleting metric %s from pushgateway %s", m.Name(), deleteUrl))
+	fmt.Println(fmt.Sprintf("Deleting metric %s with labels %s from pushgateway %s", m.Name(), groupingKey, pushUrl))
 	if !strings.Contains(deleteUrl, "://") {
 		deleteUrl = "http://" + deleteUrl
 	}

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -145,7 +145,7 @@ func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string
 	if deleted {
 		fmt.Println(fmt.Sprintf("[DEBUG] Deleted metric %s from collector %s.", m.Name(), m.Collector()))
 	} else {
-		if m.metricVec == nil {
+		if m.MetricVec() == nil {
 			fmt.Println("[DEBUG] Detected metric instead of metric vector.")
 		}
 		fmt.Println(fmt.Sprintf("[DEBUG] Failed to delete metric %s from collector %s.", m.Name(), m.Collector()))	

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -98,7 +98,7 @@ func main() {
 					if metric.NeedPush() {
 						err := pushMetric(metric, cfg.Global.PushgatewayAddr, groupingKey)
 						if err != nil {
-							fmt.Println(fmt.Sprintf("Push error: %s",err))
+							fmt.Println(fmt.Sprintf("[DEBUG] Push error: %s",err))
 							fmt.Errorf("Error pushing metric %v to pushgateway.", metric.Name())
 						}
 					}
@@ -124,13 +124,13 @@ func main() {
 }
 
 func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string) error {
-	fmt.Println(fmt.Sprintf("Pushing metric %s with labels %s to pushgateway %s of job %s", m.Name(), groupingKey, pushUrl, m.JobName()))
+	fmt.Println(fmt.Sprintf("[DEBUG] Pushing metric %s with labels %s to pushgateway %s of job %s", m.Name(), groupingKey, pushUrl, m.JobName()))
 	err := push.AddCollectors(m.JobName(), groupingKey, pushUrl, m.Collector())
 	return err
 }
 
 func deleteMetric(m exporter.Metric, deleteUrl string, groupingKey map[string]string) error {
-	fmt.Println(fmt.Sprintf("Deleting metric %s with labels %s from pushgateway %s of job %s", m.Name(), groupingKey, deleteUrl, m.JobName()))
+	fmt.Println(fmt.Sprintf("[DEBUG] Deleting metric %s with labels %s from pushgateway %s of job %s", m.Name(), groupingKey, deleteUrl, m.JobName()))
 	if !strings.Contains(deleteUrl, "://") {
 		deleteUrl = "http://" + deleteUrl
 	}
@@ -153,7 +153,6 @@ func deleteMetric(m exporter.Metric, deleteUrl string, groupingKey map[string]st
 	}
 
 	deleteUrl = fmt.Sprintf("%s/metrics/job/%s", deleteUrl, strings.Join(urlComponents, "/"))
-	fmt.Println(deleteUrl)
 
 	request, err := http.NewRequest("DELETE", deleteUrl, nil)
 	if err != nil {

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -88,7 +88,7 @@ func main() {
 			for _, metric := range metrics {
 				start := time.Now()
 				match, delete_match, groupingKey, err := metric.Process(line)
-				fmt.Println(fmt.Sprintf("Process result: match: %s, delete_match: %s, groupingKey: %s, err: %s", match, delete_match, groupingKey, err))
+				fmt.Println(fmt.Sprintf("[DEBUG] Process result: match: %s, delete_match: %s, groupingKey: %s, err: %s", match, delete_match, groupingKey, err))
 
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "WARNING: Skipping log line: %v\n", err.Error())
@@ -135,7 +135,11 @@ func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string
 		return err
 	}
 	//remove metric from registry
-	r.Unregister(m.Collector())
+	if r.Unregister(m.Collector()) {
+		fmt.Println(fmt.Sprintf("[DEBUG] Unregister collector %s from registry.", m.Collector())
+	} else {
+		fmt.Println(fmt.Sprintf("[DEBUG] Failed to unregister collector %s from registry.", m.Collector())
+	}
 	return nil
 }
 

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -97,9 +97,8 @@ func main() {
 				if match {
 					if metric.NeedPush() {
 						err := pushMetric(metric, cfg.Global.PushgatewayAddr, groupingKey)
-						fmt.Println("%s", err)
 						if err != nil {
-							fmt.Errorf("Error pushing metric %v to pushgateway.", metric.Name())
+							fmt.Println(fmt.Errorf("Error pushing metric %v to pushgateway.", metric.Name()))
 						}
 					}
 

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -179,9 +179,9 @@ func doRequest(job string, groupingKey map[string]string, targetUrl string, g pr
 	var request *http.Request
 	var err error
 	if method == "DELETE" {
-		request, err := http.NewRequest(method, targetUrl, nil)	
+		request, err = http.NewRequest(method, targetUrl, nil)	
 	} else {
-		request, err := http.NewRequest(method, targetUrl, buf)
+		request, err = http.NewRequest(method, targetUrl, buf)
 	}
 	
 	if err != nil {

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -121,23 +121,23 @@ func main() {
 	}
 }
 
-func pushMetric(m exporter.Metric, url string, groupingKey map[string]string) error {
-	err := push.Collectors(m.getJobName(), groupingKey, url, m.Collector())
+func pushMetric(m exporter.Metric, pushUrl string, groupingKey map[string]string) error {
+	err := push.Collectors(m.JobName(), groupingKey, pushUrl, m.Collector())
 	return err
 }
 
 func deleteMetric(m exporter.Metric, deleteUrl string, groupingKey map[string]string) error {
-	if !strings.Contains(url, "://") {
-		deleteUrl = "http://" + url
+	if !strings.Contains(deleteUrl, "://") {
+		deleteUrl = "http://" + deleteUrl
 	}
-	if strings.HasSuffix(url, "/") {
-		deleteUrl = url[:len(url)-1]
+	if strings.HasSuffix(deleteUrl, "/") {
+		deleteUrl = deleteUrl[:len(deleteUrl)-1]
 	}
 
-	if strings.Contains(m.getJobName(), "/") {
-		return fmt.Errorf("job contains '/' : %s", m.getJobName())
+	if strings.Contains(m.JobName(), "/") {
+		return fmt.Errorf("job contains '/' : %s", m.JobName())
 	}
-	urlComponents := []string{url.QueryEscape(m.getJobName())}
+	urlComponents := []string{url.QueryEscape(m.JobName())}
 	for ln, lv := range groupingKey {
 		if !model.LabelName(ln).IsValid() {
 			return fmt.Errorf("groupingKey label has invalid name: %s", ln)

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -151,7 +151,8 @@ func deleteMetric(m exporter.Metric, deleteUrl string, groupingKey map[string]st
 	}
 
 	deleteUrl = fmt.Sprintf("%s/metrics/job/%s", deleteUrl, strings.Join(urlComponents, "/"))
-
+	fmt.Println(deleteUrl)
+	
 	request, err := http.NewRequest("DELETE", deleteUrl, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
Add config attributes for handling pushgateway (pushing or deleting metrics)

Added config attributes:
**global section:**
   `pushgateway_addr: <ip>:<port>` : specify target pushgateway address.

**metrics section:**
  `pushgateway: <bool>`: specify if the metric needs to be pushed, default false.

  `job_name`: specify job name when pushing.

  `delete_match`: similar to "match", if log line matches this attributes, the corresponding metric will be deleted from pushgateway.

  `grouping_key`: specify groupKey when pushing.
