### PR TITLE
logrotate: Support MOVE_TO event

### DIFF
--- a/tailer/fileTailer_linux.go
+++ b/tailer/fileTailer_linux.go
@@ -34,7 +34,7 @@ func NewFseventWatcher(abspath string, _ *File) (Watcher, error) {
 	if err != nil {
 		return nil, err
 	}
-	wd, err := syscall.InotifyAddWatch(fd, filepath.Dir(abspath), syscall.IN_MODIFY|syscall.IN_MOVED_FROM|syscall.IN_DELETE|syscall.IN_CREATE)
+	wd, err := syscall.InotifyAddWatch(fd, filepath.Dir(abspath), syscall.IN_MODIFY|syscall.IN_MOVED_FROM|syscall.IN_MOVED_TO|syscall.IN_DELETE|syscall.IN_CREATE)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func (events eventList) Process(fileBefore *File, reader *bufferedLineReader, ab
 		}
 	}
 
-	// MOVE or DELETE
+	// MOVED_FROM or DELETE
 	for _, event := range events {
 		if file != nil && event.Name == filename && (event.Mask&syscall.IN_MOVED_FROM == syscall.IN_MOVED_FROM || event.Mask&syscall.IN_DELETE == syscall.IN_DELETE) {
 			file.Close()
@@ -181,9 +181,9 @@ func (events eventList) Process(fileBefore *File, reader *bufferedLineReader, ab
 		}
 	}
 
-	// CREATE
+	// CREATE or MOVED_TO
 	for _, event := range events {
-		if file == nil && event.Name == filename && event.Mask&syscall.IN_CREATE == syscall.IN_CREATE {
+		if file == nil && event.Name == filename && (event.Mask&syscall.IN_CREATE == syscall.IN_CREATE || event.Mask&syscall.IN_MOVED_TO == syscall.IN_MOVED_TO) {
 			file, err = open(abspath)
 			if err != nil {
 				return

--- a/tailer/fileTailer_test.go
+++ b/tailer/fileTailer_test.go
@@ -98,7 +98,7 @@ func (opt loggerOption) String() string {
 func TestFileTailerCloseLogfileAfterEachLine(t *testing.T) {
 	testRunNumber := 0 // Helps to figure out which debug message belongs to which test run.
 	for _, watcherOpt := range []watcherType{fsevent, polling} {
-		for _, logrotateOpt := range []logrotateOption{_create, _nocreate} { //, _create_from_temp} {
+		for _, logrotateOpt := range []logrotateOption{_create, _nocreate, _create_from_temp} {
 			for _, mvOpt := range []logrotateMoveOption{mv, cp, rm} {
 				testRunNumber++
 				testLogrotate(t, NewTestRunLogger(testRunNumber), watcherOpt, logrotateOpt, mvOpt, closeFileAfterEachLine)


### PR DESCRIPTION
Some versions of Logrotate create a temp file then move it to the actual
file. We need to take into consideration MOVE_TO inotify calls.

Fix #19

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>