### PR TITLE
Don't emit grok_exporter specific message in tailer package

### DIFF
--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -77,6 +77,9 @@ func main() {
 		case err := <-serverErrors:
 			exitOnError(fmt.Errorf("server error: %v", err.Error()))
 		case err := <-tail.Errors():
+			if os.IsNotExist(err) {
+				exitOnError(fmt.Errorf("error reading log lines: %v. use 'fail_on_missing_logfile: false' in the input configuration if you want grok_exporter to start even though the logfile is missing", err))
+			}
 			exitOnError(fmt.Errorf("error reading log lines: %v", err.Error()))
 		case line := <-tail.Lines():
 			matched := false

--- a/tailer/fileTailer.go
+++ b/tailer/fileTailer.go
@@ -180,9 +180,6 @@ func openLogfile(path string, readall bool, failOnMissingFile bool) (*File, stri
 	}
 	file, err := open(abspath)
 	if err != nil {
-		if failOnMissingFile && os.IsNotExist(err) {
-			return nil, "", fmt.Errorf("%v. use 'fail_on_missing_logfile: false' in the input configuration if you want grok_exporter to start even though the logfile is missing", err)
-		}
 		if failOnMissingFile || !os.IsNotExist(err) {
 			return nil, "", err
 		}


### PR DESCRIPTION
I really enjoyed your writeup about the tailer package, and it's definitely the best pure go tail solution out there. The tailer package is immensely useful, it should be it's own project!

But, until that day, one nit is that it has a grok_exporter specific message in it, which is confusing if your application isn't grok_exporter... 

Disclaimer: I haven't actually tested this code yet since I don't use grok_exporter itself, but this seems like the right fix.