### PR TITLE
Added Dockerfile suitable for DockerHub Auto-Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+#############################
+# Multi-Stage Build
+
+FROM golang:stretch as builder
+
+# Install system deps
+#   We need this in order to build oniguruma.
+#   The debian deb packages for onigurma do not install static libs
+RUN apt-get update && apt-get -y install build-essential make autoconf libtool
+
+# Oniguruma: fetch, build, and install static libs
+RUN cd /tmp && \
+    git clone https://github.com/kkos/oniguruma.git && \
+    cd /tmp/oniguruma && \
+    autoreconf -vfi && \
+    ./configure && \
+    make && \
+    make install
+
+# grok_exporter: fetch source code
+RUN mkdir -p /go/src/github.com/fstab && \
+    cd /go/src/github.com/fstab && \
+    git clone https://github.com/fstab/grok_exporter.git
+
+# Fetch Golang Dependencies
+RUN cd /go/src/github.com/fstab/grok_exporter && \
+  git submodule update --init --recursive && \
+  go get
+
+
+# Build Statically-Linked Binary
+RUN cd /go/src/github.com/fstab/grok_exporter && \
+  GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build \
+    -ldflags "-w -extldflags \"-static\" \
+    -X github.com/fstab/grok_exporter/exporter.Version=$VERSION \
+    -X github.com/fstab/grok_exporter/exporter.BuildDate=$(date +%Y-%m-%d) \
+    -X github.com/fstab/grok_exporter/exporter.Branch=$(git rev-parse --abbrev-ref HEAD) \
+    -X github.com/fstab/grok_exporter/exporter.Revision=$(git rev-parse --short HEAD) \
+    "
+
+#############################
+# Final-Stage Build
+
+FROM alpine:latest
+
+COPY --from=builder /go/src/github.com/fstab/grok_exporter/grok_exporter \
+     /bin/grok_exporter
+
+EXPOSE 9144
+ENTRYPOINT [ "/bin/grok_exporter" ]


### PR DESCRIPTION
Hi @fstab,

This PR adds a Dockerfile for grok_exporter which builds an alpine linux docker image which contains a statically compiled grok_exporter binary.  This should be suitable for DockerHub Auto-builds.  If you wanted, you could go to dockerhub and create a connected public repository with the following build settings which will auto-build a "latest" docker image upon master branch changes, and auto-build a "vX.Y.Z" docker image upon repo tagging.

<img width="936" alt="image" src="https://user-images.githubusercontent.com/1733071/57586638-625df600-74ad-11e9-9a2c-3ca46803d567.png">

Thanks!
-dave