### PR TITLE
Allow quoted keys in yaml config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,7 @@ func LoadConfigString(content []byte) (*v2.Config, string, error) {
 }
 
 func findVersion(content string) (int, string, error) {
-	versionExpr := regexp.MustCompile(`global:\s*config_version:[\t\f ]*(\S+)`)
+	versionExpr := regexp.MustCompile(`"?global"?:\s*"?config_version"?:[\t\f ]*(\S+)`)
 	versionInfo := versionExpr.FindStringSubmatch(content)
 	if len(versionInfo) == 2 {
 		version, err := strconv.Atoi(strings.TrimSpace(versionInfo[1]))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -42,6 +42,8 @@ func TestVersionDetection(t *testing.T) {
 	expectVersion(t, exampleConfig, 2, false)
 	expectVersion(t, strings.Replace(exampleConfig, "config_version: 2", "config_version: 1", 1), 1, false)
 	expectVersion(t, strings.Replace(exampleConfig, "config_version: 2", "config_version:", 1), 1, true)
+	expectVersion(t, strings.Replace(exampleConfig, "config_version: 2", "\"config_version\": 2", 1), 2, false)
+	expectVersion(t, strings.Replace(exampleConfig, "global", "\"global\"", 1), 2, false)
 	expectVersion(t, strings.Replace(exampleConfig, "config_version: 2", "", 1), 1, true)
 	_, _, err := findVersion(strings.Replace(exampleConfig, "config_version: 2", "config_version: a", 1))
 	if err == nil {


### PR DESCRIPTION
Fix grok_exporter failure to start when the keys in the yaml config file are quoted.
Both the below formats are now parsed correctly.
```yaml
"global":
  "config_version": 2
```
as well as the original one without quotes:
```yaml
global:
  config_version: 2
```