### PR TITLE
WIP: Feature/extra template context

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Fabian Stäber <fabian@fstab.de>
+Emil Madsen <emil@magenta.dk>

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -343,7 +343,13 @@ This simple example shows a one-to-one mapping of a Grok field to a Prometheus l
 
 ### Pre-Defined Label Variables
 
-`logfile` is currently the only pre-defined label variable that is independent of the Grok patterns. The `logfile` variable is always present for input type `file`, and contains the full path to the log file the line was read from. You can use it like this:
+Two pre-defined label variables, that are independent of Grok patterns are defined, namely:
+* `logfile`: Which contains the full path of the log file the line was read from (for input type `file`).
+* `extra`: Which contains the entire JSON object parsed from the input (for input type `webhook`, with format=`json_*`).
+
+#### logfile
+The `logfile` variable is always present for input type `file`, and contains the full path to the log file the line was read from.
+You can use it like this:
 
 ```yaml
 match: '%{DATE} %{TIME} %{USER:user} %{NUMBER:val}'
@@ -353,6 +359,24 @@ labels:
 ```
 
 If you don't want the full path but only the file name, you can use the `base` template function, see next section.
+
+#### extra
+The `extra` variable is always present for input type `webhook` with format being either `json_single` or `json_bulk`.
+It contains the entire JSON object that was parsed.
+You can use it like this:
+
+```yaml
+match: 'Login occured'
+labels:
+    user: '{{ index .extra "user" }}'
+    ip: '{{ index .extra "ip" }}'
+```
+
+With the incoming log object being:
+
+```json
+{"message": "Login occured", "user": "Skeen", "ip": "1.1.1.1"}'
+```
 
 ### Label Template Functions
 

--- a/exporter/metrics_test.go
+++ b/exporter/metrics_test.go
@@ -86,10 +86,10 @@ func TestLogfileLabel(t *testing.T) {
 			"logfile":       "{{.logfile}}",
 		},
 	})
-	logfile1 := map[string]string{
+	logfile1 := map[string]interface{}{
 		"logfile": "/var/log/exim-1.log",
 	}
-	logfile2 := map[string]string{
+	logfile2 := map[string]interface{}{
 		"logfile": "/var/log/exim-2.log",
 	}
 	counter := NewCounterMetric(counterCfg, regex, nil)

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -162,8 +162,8 @@ func main() {
 	}
 }
 
-func makeAdditionalFields(line *fswatcher.Line) map[string]string {
-	return map[string]string{
+func makeAdditionalFields(line *fswatcher.Line) map[string]interface{} {
+	return map[string]interface{}{
 		logfile: line.File,
 	}
 }

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -40,6 +40,7 @@ var (
 
 var (
 	logfile = "logfile"
+	extra = "extra"
 )
 
 const (
@@ -49,6 +50,7 @@ const (
 
 var additionalFieldDefinitions = map[string]string{
 	logfile: "full path of the log file",
+	extra: "full json log object",
 }
 
 func main() {
@@ -165,6 +167,7 @@ func main() {
 func makeAdditionalFields(line *fswatcher.Line) map[string]interface{} {
 	return map[string]interface{}{
 		logfile: line.File,
+		extra: line.Extra,
 	}
 }
 

--- a/tailer/fswatcher/fswatcher.go
+++ b/tailer/fswatcher/fswatcher.go
@@ -34,6 +34,7 @@ type FileTailer interface {
 type Line struct {
 	Line string
 	File string
+	Extra interface{}
 }
 
 // ideas how this might look like in the config file:

--- a/tailer/webhookTailer_test.go
+++ b/tailer/webhookTailer_test.go
@@ -250,7 +250,7 @@ func TestArraySelector(t *testing.T) {
 			}
 			lines := WebhookProcessBody(config, []byte(json))
 			expected := fmt.Sprintf("line %v", lineNumber)
-			if len(lines) != 1 || lines[0] != expected {
+			if len(lines) != 1 || lines[0].line != expected {
 				t.Fatalf("Expected: []string{\"%v\"}, Actual: %#v", expected, lines)
 			}
 		}

--- a/tailer/webhookTailer_test.go
+++ b/tailer/webhookTailer_test.go
@@ -36,7 +36,7 @@ func TestWebhookTextSingle(t *testing.T) {
 	if len(lines) != 1 {
 		t.Fatal("Expected 1 line processed")
 	}
-	if lines[0] != message {
+	if lines[0].line != message {
 		t.Fatal("Expected line to match")
 	}
 }
@@ -62,7 +62,7 @@ func TestWebhookTextBulk(t *testing.T) {
 		t.Fatal("Expected number of lines to equal number of messages")
 	}
 	for i := range messages {
-		if messages[i] != lines[i] {
+		if messages[i] != lines[i].line {
 			t.Fatal("Expected line to match")
 		}
 	}
@@ -110,7 +110,7 @@ func TestWebhookJsonSingle(t *testing.T) {
 	if len(lines) != 1 {
 		t.Fatal("Expected 1 line processed")
 	}
-	if lines[0] != message {
+	if lines[0].line != message {
 		t.Fatal("Expected line to match")
 	}
 }
@@ -183,7 +183,7 @@ func TestWebhookJsonBulk(t *testing.T) {
 		t.Fatal("Expected number of lines to equal number of messages")
 	}
 	for i := range messages {
-		if messages[i] != lines[i] {
+		if messages[i] != lines[i].line {
 			t.Fatal("Expected line to match")
 		}
 	}

--- a/template/arithmetic_test.go
+++ b/template/arithmetic_test.go
@@ -44,7 +44,7 @@ func TestArithmeticFunctions(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error parsing template %v: %v", data.template, err)
 		}
-		result, err := template.Execute(map[string]string{
+		result, err := template.Execute(map[string]interface{}{
 			"val": data.val,
 		})
 		if data.execError {

--- a/template/gsub_test.go
+++ b/template/gsub_test.go
@@ -25,7 +25,7 @@ func TestGsubFunction(t *testing.T) {
 		t.Fatalf("unexpected error parsing template: %v", err)
 		return
 	}
-	result, err := template.Execute(map[string]string{
+	result, err := template.Execute(map[string]interface{}{
 		"url": "http://example.com/foo.asp?id=42&source=github&foo=bar",
 	})
 	if err != nil {
@@ -43,7 +43,7 @@ func TestNestedGsub(t *testing.T) {
 		t.Fatalf("unexpected error parsing template: %v", err)
 		return
 	}
-	result, err := template.Execute(map[string]string{
+	result, err := template.Execute(map[string]interface{}{
 		"message": "Sender verify failed",
 	})
 	if err != nil {

--- a/template/template.go
+++ b/template/template.go
@@ -26,7 +26,7 @@ import (
 // Executing this template is similar to text/template.Template.Execute(), and
 // ReferencedGrokFields() yields {"field1", "field2", "field3"}
 type Template interface {
-	Execute(grokValues map[string]string) (string, error)
+	Execute(grokValues map[string]interface{}) (string, error)
 	ReferencedGrokFields() []string
 	Name() string
 }
@@ -57,7 +57,7 @@ func (t *templateImpl) Name() string {
 	return t.template.Name()
 }
 
-func (t *templateImpl) Execute(grokValues map[string]string) (string, error) {
+func (t *templateImpl) Execute(grokValues map[string]interface{}) (string, error) {
 	var buf bytes.Buffer
 	err := t.template.Execute(&buf, grokValues)
 	if err != nil {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -36,7 +36,7 @@ func TestReferencedGrokFields(t *testing.T) {
 	for i, test := range []struct {
 		template           string
 		expectedGrokFields []string
-		example            map[string]string
+		example            map[string]interface{}
 		expectedResult     string
 	}{
 		// The template examples below are from Go's text/template documentation
@@ -45,21 +45,21 @@ func TestReferencedGrokFields(t *testing.T) {
 			// {{/* a comment */}}
 			template:           "{{/* a comment {.field} should be ignored */}}",
 			expectedGrokFields: []string{},
-			example:            map[string]string{},
+			example:            map[string]interface{}{},
 			expectedResult:     "",
 		},
 		{
 			// {{pipeline}} with fixed string
 			template:           "42",
 			expectedGrokFields: []string{},
-			example:            map[string]string{},
+			example:            map[string]interface{}{},
 			expectedResult:     "42",
 		},
 		{
 			// {{pipeline}} with simple values
 			template:           "{{.count_total}} items are made of {{.material}}",
 			expectedGrokFields: []string{"count_total", "material"},
-			example: map[string]string{
+			example: map[string]interface{}{
 				"count_total": "3",
 				"material":    "metal",
 			},
@@ -69,7 +69,7 @@ func TestReferencedGrokFields(t *testing.T) {
 			// {{pipeline}} with function call
 			template:           "{{.count_total}} items are made {{printf \"of %v\" .material}}",
 			expectedGrokFields: []string{"count_total", "material"},
-			example: map[string]string{
+			example: map[string]interface{}{
 				"count_total": "3",
 				"material":    "metal",
 			},
@@ -79,7 +79,7 @@ func TestReferencedGrokFields(t *testing.T) {
 			// {{if pipeline}} T1 {{end}}
 			template:           "{{if eq .field1 .field2}}{{.field3}}{{end}}",
 			expectedGrokFields: []string{"field1", "field2", "field3"},
-			example: map[string]string{
+			example: map[string]interface{}{
 				"field1": "a",
 				"field2": "b",
 				"field3": "c",
@@ -90,7 +90,7 @@ func TestReferencedGrokFields(t *testing.T) {
 			// {{if pipeline}} T1 {{else}} T0 {{end}}
 			template:           "{{if eq .field1 .field2}}{{.field3}}{{else}}{{.field4}}{{end}}",
 			expectedGrokFields: []string{"field1", "field2", "field3", "field4"},
-			example: map[string]string{
+			example: map[string]interface{}{
 				"field1": "a",
 				"field2": "b",
 				"field3": "c",
@@ -102,7 +102,7 @@ func TestReferencedGrokFields(t *testing.T) {
 			// {{if pipeline}} T1 {{else if pipeline}} T0 {{end}}
 			template:           "{{if eq .field1 .field2}}{{.field3}}{{else if eq .field4 .field5}}{{.field6}}{{end}}",
 			expectedGrokFields: []string{"field1", "field2", "field3", "field4", "field5", "field6"},
-			example: map[string]string{
+			example: map[string]interface{}{
 				"field1": "a",
 				"field2": "b",
 				"field3": "c",
@@ -116,7 +116,7 @@ func TestReferencedGrokFields(t *testing.T) {
 			// {{range pipeline}} T1 {{end}}
 			template:           "{{range testarray .field1 \" vs \" .field2}}{{printf \"%v\" .}}{{end}}",
 			expectedGrokFields: []string{"field1", "field2"},
-			example: map[string]string{
+			example: map[string]interface{}{
 				"field1": "23",
 				"field2": "42",
 			},
@@ -126,7 +126,7 @@ func TestReferencedGrokFields(t *testing.T) {
 			// {{range pipeline}} T1 {{else}} T0 {{end}}
 			template:           "{{range testarray \"42\"}}{{.}}{{else}}{{.field}}{{end}}",
 			expectedGrokFields: []string{"field"},
-			example: map[string]string{
+			example: map[string]interface{}{
 				"field": "128",
 			},
 			expectedResult: "42",
@@ -135,14 +135,14 @@ func TestReferencedGrokFields(t *testing.T) {
 			// {{template "name"}}
 			template:           "{{define \"T1\"}}some constant{{end}}{{template \"T1\"}}",
 			expectedGrokFields: []string{},
-			example:            map[string]string{},
+			example:            map[string]interface{}{},
 			expectedResult:     "some constant",
 		},
 		{
 			// {{template "name" pipeline}}
 			template:           "{{define \"T1\"}}{{print .field1 \".\" .field2}}{{end}}{{template \"T1\" .}}",
 			expectedGrokFields: []string{"field1", "field2"},
-			example: map[string]string{
+			example: map[string]interface{}{
 				"field1": "3",
 				"field2": "4",
 			},
@@ -152,7 +152,7 @@ func TestReferencedGrokFields(t *testing.T) {
 			// {{block "name" pipeline}} T1 {{end}}
 			template:           "{{block \"T1\" .}}{{print .field1}}{{end}}",
 			expectedGrokFields: []string{"field1"},
-			example: map[string]string{
+			example: map[string]interface{}{
 				"field1": "17",
 				"field2": "18",
 			},
@@ -162,7 +162,7 @@ func TestReferencedGrokFields(t *testing.T) {
 			// {{with pipeline}} T1 {{end}}
 			template:           "{{with .field}}{{.}}{{end}}",
 			expectedGrokFields: []string{"field"},
-			example: map[string]string{
+			example: map[string]interface{}{
 				"field": "23",
 			},
 			expectedResult: "23",
@@ -171,7 +171,7 @@ func TestReferencedGrokFields(t *testing.T) {
 			// {{with pipeline}} T1 {{else}} T0 {{end}}
 			template:           "{{with .field1}}{{.}}{{else}}{{.field2}}{{end}}",
 			expectedGrokFields: []string{"field1", "field2"},
-			example: map[string]string{
+			example: map[string]interface{}{
 				"field1": "23",
 				"field2": "42",
 			},
@@ -183,7 +183,7 @@ func TestReferencedGrokFields(t *testing.T) {
 		{
 			template:           "{{if eq .field1 .field2}}{{.field3}}{{else if eq .field4 .field5}}{{.field6}}{{else}}{{.field7}}{{end}}",
 			expectedGrokFields: []string{"field1", "field2", "field3", "field4", "field5", "field6", "field7"},
-			example: map[string]string{
+			example: map[string]interface{}{
 				"field1": "1",
 				"field2": "2",
 				"field3": "3",
@@ -197,7 +197,7 @@ func TestReferencedGrokFields(t *testing.T) {
 		{
 			template:           "{{if eq .val2 \"test\"}}yes{{else}}no{{end}}",
 			expectedGrokFields: []string{"val2"},
-			example: map[string]string{
+			example: map[string]interface{}{
 				"val2": "test",
 			},
 			expectedResult: "yes",
@@ -205,7 +205,7 @@ func TestReferencedGrokFields(t *testing.T) {
 		{
 			template:           "{{with $x := .field}}This is $x: {{$x}}{{end}}",
 			expectedGrokFields: []string{"field"},
-			example: map[string]string{
+			example: map[string]interface{}{
 				"field": "128",
 			},
 			expectedResult: "This is $x: 128",
@@ -213,7 +213,7 @@ func TestReferencedGrokFields(t *testing.T) {
 		{
 			template:           "{{define \"T1\"}}{{.}}{{end}}{{template \"T1\" .field}}",
 			expectedGrokFields: []string{"field"},
-			example: map[string]string{
+			example: map[string]interface{}{
 				"field": "77",
 			},
 			expectedResult: "77",

--- a/template/timestamp_test.go
+++ b/template/timestamp_test.go
@@ -58,7 +58,7 @@ func TestTimestampCommaError(t *testing.T) {
 }
 
 func evalTimestamp(t *testing.T, template Template, value string) float64 {
-	resultString, err := template.Execute(map[string]string{
+	resultString, err := template.Execute(map[string]interface{}{
 		"date": value,
 	})
 	if err != nil {


### PR DESCRIPTION
This PR introduces a new pre-defined label variable, namely `extra`, which contains the entire JSON object parsed from the input, when using input type `webhook` with format being either `json_single` or `json_bulk`.

It is flexible enough to be utilized by any input, which may want to provide a map as extra context for the label templating step.

The majority of changes has been made in the initial commit [6ee14ae](https://github.com/fstab/grok_exporter/commit/6ee14ae617070715205b76a7d795a1575c47c289), and simply involves changing the type of `additionalFields` from `map[string]string` to `map[string]interface{}` in order to support proper recursive data structures as extra context.

An argument could have been made to go all the way to `data interface{}` as this is the type utilized for the `Execute` method's `data` argument on the `Template` type, however `map[string]interface{}` seemed like a good compromise.