### PR TITLE
WIP: Feature/value on counter

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -458,7 +458,8 @@ metrics:
     - type: counter
       name: grok_example_lines_total
       help: Example counter metric with labels.
-      match: '%{DATE} %{TIME} %{USER:user} %{NUMBER}'
+      match: '%{DATE} %{TIME} %{USER:user} %{NUMBER:val}'
+      value: '{{.val}}'
       labels:
           user: '{{.user}}'
 ```
@@ -468,6 +469,7 @@ The configuration is as follows:
 * `name` is the name of the metric. Metric names are described in the [Prometheus data model documentation].
 * `help` is a comment describing the metric.
 * `match` is the Grok expression. See the [Grok documentation] for more info.
+* `value` is an optional [Go template] for the value to be monitored. The template must evaluate to a valid positive number. The template may use to Grok fields from the `match` patterns, like the label templates described above.
 * `labels` is an optional map of name/template pairs, as described above.
 
 Output for the example log lines above:

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -163,14 +163,14 @@ func (m *summaryVecMetric) Collector() prometheus.Collector {
 	return m.summaryVec
 }
 
-func (m *metric) processMatch(line string, cb func()) (*Match, error) {
+func (m *metric) processMatch(line string, callback func()) (*Match, error) {
 	searchResult, err := m.regex.Search(line)
 	if err != nil {
 		return nil, fmt.Errorf("error processing metric %v: %v", m.Name(), err.Error())
 	}
 	defer searchResult.Free()
 	if searchResult.IsMatch() {
-		cb()
+		callback()
 		return &Match{
 			Value: 1.0,
 		}, nil
@@ -179,7 +179,7 @@ func (m *metric) processMatch(line string, cb func()) (*Match, error) {
 	}
 }
 
-func (m *observeMetric) processMatch(line string, cb func(value float64)) (*Match, error) {
+func (m *observeMetric) processMatch(line string, callback func(value float64)) (*Match, error) {
 	searchResult, err := m.regex.Search(line)
 	if err != nil {
 		return nil, fmt.Errorf("error processing metric %v: %v", m.Name(), err.Error())
@@ -190,7 +190,7 @@ func (m *observeMetric) processMatch(line string, cb func(value float64)) (*Matc
 		if err != nil {
 			return nil, err
 		}
-		cb(floatVal)
+		callback(floatVal)
 		return &Match{
 			Value: floatVal,
 		}, nil

--- a/exporter/metrics.go
+++ b/exporter/metrics.go
@@ -404,12 +404,12 @@ func NewCounterMetric(cfg *configuration.MetricConfig, regex *oniguruma.Regex, d
 	if len(cfg.Labels) == 0 {
 		return &counterMetric{
 			observeMetric: newObserveMetric(cfg, regex, deleteRegex),
-			counter: prometheus.NewCounter(counterOpts),
+			counter:       prometheus.NewCounter(counterOpts),
 		}
 	} else {
 		return &counterVecMetric{
 			observeMetricWithLabels: newObserveMetricWithLabels(cfg, regex, deleteRegex),
-			counterVec:		 prometheus.NewCounterVec(counterOpts, prometheusLabels(cfg.LabelTemplates)),
+			counterVec:              prometheus.NewCounterVec(counterOpts, prometheusLabels(cfg.LabelTemplates)),
 		}
 	}
 }

--- a/exporter/metrics_test.go
+++ b/exporter/metrics_test.go
@@ -227,6 +227,10 @@ func initGaugeRegex(t *testing.T) *oniguruma.Regex {
 }
 
 func newMetricConfig(t *testing.T, cfg *configuration.MetricConfig) *configuration.MetricConfig {
+	// Handle default for counter's value
+	if len(cfg.Value) == 0 {
+		cfg.Value = "1.0"
+	}
 	err := cfg.InitTemplates()
 	if err != nil {
 		t.Fatal(err)

--- a/exporter/metrics_test.go
+++ b/exporter/metrics_test.go
@@ -260,7 +260,8 @@ func initCumulativeRegex(t *testing.T) *oniguruma.Regex {
 
 func newMetricConfig(t *testing.T, cfg *configuration.MetricConfig) *configuration.MetricConfig {
 	// Handle default for counter's value
-	if cfg.Type == "counter" && len(cfg.Value) == 0 {
+	// Note: cfg.Type is not set here
+	if len(cfg.Value) == 0 {
 		cfg.Value = "1.0"
 	}
 	err := cfg.InitTemplates()

--- a/exporter/metrics_test.go
+++ b/exporter/metrics_test.go
@@ -77,6 +77,29 @@ func TestCounter(t *testing.T) {
 	}
 }
 
+func TestCounterValue(t *testing.T) {
+	regex := initCumulativeRegex(t)
+	counterCfg := newMetricConfig(t, &configuration.MetricConfig{
+		Name:       "rainfall",
+		Value:      "{{.rainfall}}",
+	})
+	counter := NewCounterMetric(counterCfg, regex, nil)
+
+	counter.ProcessMatch("Rainfall in Berlin: 32", nil)
+	counter.ProcessMatch("Rainfall in Berlin: 5", nil)
+
+	switch c := counter.Collector().(type) {
+	case prometheus.Counter:
+		m := io_prometheus_client.Metric{}
+		c.Write(&m)
+		if *m.Counter.Value != float64(37) {
+			t.Errorf("Expected 37 as counter value, but got %v.", *m.Counter.Value)
+		}
+	default:
+		t.Errorf("Unexpected type of metric: %v", reflect.TypeOf(c))
+	}
+}
+
 func TestLogfileLabel(t *testing.T) {
 	regex := initCounterRegex(t)
 	counterCfg := newMetricConfig(t, &configuration.MetricConfig{
@@ -163,23 +186,23 @@ func TestGauge(t *testing.T) {
 }
 
 func TestGaugeCumulative(t *testing.T) {
-	regex := initGaugeRegex(t)
+	regex := initCumulativeRegex(t)
 	gaugeCfg := newMetricConfig(t, &configuration.MetricConfig{
-		Name:       "temperature",
-		Value:      "{{.temperature}}",
+		Name:       "rainfall",
+		Value:      "{{.rainfall}}",
 		Cumulative: true,
 	})
 	gauge := NewGaugeMetric(gaugeCfg, regex, nil)
 
-	gauge.ProcessMatch("Temperature in Berlin: 32", nil)
-	gauge.ProcessMatch("Temperature in Moscow: -5", nil)
+	gauge.ProcessMatch("Rainfall in Berlin: 32", nil)
+	gauge.ProcessMatch("Rainfall in Moscow: 5", nil)
 
 	switch c := gauge.Collector().(type) {
 	case prometheus.Gauge:
 		m := io_prometheus_client.Metric{}
 		c.Write(&m)
-		if *m.Gauge.Value != float64(27) {
-			t.Errorf("Expected 27 as cumulative value, but got %v.", *m.Gauge.Value)
+		if *m.Gauge.Value != float64(37) {
+			t.Errorf("Expected 37 as cumulative value, but got %v.", *m.Gauge.Value)
 		}
 	default:
 		t.Errorf("Unexpected type of metric: %v", reflect.TypeOf(c))
@@ -220,6 +243,15 @@ func TestGaugeVec(t *testing.T) {
 func initGaugeRegex(t *testing.T) *oniguruma.Regex {
 	patterns := loadPatternDir(t)
 	regex, err := Compile("Temperature in %{WORD:city}: %{INT:temperature}", patterns)
+	if err != nil {
+		t.Error(err)
+	}
+	return regex
+}
+
+func initCumulativeRegex(t *testing.T) *oniguruma.Regex {
+	patterns := loadPatternDir(t)
+	regex, err := Compile("Rainfall in %{WORD:city}: %{INT:rainfall}", patterns)
 	if err != nil {
 		t.Error(err)
 	}

--- a/exporter/metrics_test.go
+++ b/exporter/metrics_test.go
@@ -228,7 +228,7 @@ func initGaugeRegex(t *testing.T) *oniguruma.Regex {
 
 func newMetricConfig(t *testing.T, cfg *configuration.MetricConfig) *configuration.MetricConfig {
 	// Handle default for counter's value
-	if len(cfg.Value) == 0 {
+	if cfg.Type == "counter" && len(cfg.Value) == 0 {
 		cfg.Value = "1.0"
 	}
 	err := cfg.InitTemplates()

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -130,8 +130,7 @@ func main() {
 					fmt.Fprintf(os.Stderr, "WARNING: skipping log line: %v\n", err.Error())
 					fmt.Fprintf(os.Stderr, "%v\n", line.Line)
 					nErrorsByMetric.WithLabelValues(metric.Name()).Inc()
-				}
-				if match != nil {
+				} else if match != nil {
 					nMatchesByMetric.WithLabelValues(metric.Name()).Inc()
 					procTimeMicrosecondsByMetric.WithLabelValues(metric.Name()).Add(float64(time.Since(start).Nanoseconds() / int64(1000)))
 					matched = true


### PR DESCRIPTION
This PR introduces adds an optional configuration field to the `counter` metric type, namely the `value` template field, also seen on the gauge.

It enables counting up with more than one, a motivating example could be for instance counting time spent or bytes ingested, both of which are monotonically increasing, and thus not will fit as gauges. 

The PR has several commits;
* [050c2e5](https://github.com/fstab/grok_exporter/commit/050c2e5ec29da9da4227efdabb4adf123acb2406) renames two callbacks from cb to callback for consistency.
* [877a386](https://github.com/fstab/grok_exporter/commit/877a386956fa7795906b005c139a3ecc4b2bb6d6) prepares for support for the counter, by allowing the callbacks to reject samples, specifically to reject floats which are negative for the counter. The change is made throughout to support future needs for late sample rejection.
* [cdba743](https://github.com/fstab/grok_exporter/commit/cdba743726d1e0e09c1bc042770b44c7b2119e1b) changes the counter into an observeMetric and changes configuration to allow for the value key.
* [25314da](https://github.com/fstab/grok_exporter/commit/25314daca0c3cdee59a172d5f9097cc9e85a5bfd) updates the documentation, such that the optional field of value is reflected for the counter metric.