### PR TITLE
Add json_lines webhook input format

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -183,6 +183,14 @@ input:
     #   POST body envelope must be a json array "[ <entry>, <entry> ]".  Log
     #   entry text is selected from the value of a json key determined by
     #   webhook_json_selector.
+    # json_lines: Webhook POST body contains multiple json log entries, with
+    #   newline-separated log lines holding an individual json object. JSON
+    #   object itself may not contain newlines. For example:
+    #   example:
+    #       { app="foo", stage="prod", log="example log message" }
+    #       { app="bar", stage="dev", log="another line" }
+    #   Log entry text is selected from the value of a json key determined
+    #   by webhook_json_selector. 
     # Default is `text_single`
     webhook_format: json_bulk
 
@@ -361,7 +369,7 @@ labels:
 If you don't want the full path but only the file name, you can use the `base` template function, see next section.
 
 #### extra
-The `extra` variable is always present for input type `webhook` with format being either `json_single` or `json_bulk`.
+The `extra` variable is always present for input type `webhook` with format being either `json_single`, `json_lines` or `json_bulk`.
 It contains the entire JSON object that was parsed.
 You can use it like this:
 

--- a/config/v3/configV3.go
+++ b/config/v3/configV3.go
@@ -371,8 +371,8 @@ func (c *InputConfig) validate() error {
 		} else if c.WebhookPath[0] != '/' {
 			return fmt.Errorf("invalid input configuration: 'input.webhook_path' must start with \"/\"")
 		}
-		if c.WebhookFormat != "text_single" && c.WebhookFormat != "text_bulk" && c.WebhookFormat != "json_single" && c.WebhookFormat != "json_bulk" {
-			return fmt.Errorf("invalid input configuration: 'input.webhook_format' must be \"text_single|text_bulk|json_single|json_bulk\"")
+		if c.WebhookFormat != "text_single" && c.WebhookFormat != "text_bulk" && c.WebhookFormat != "json_single" && c.WebhookFormat != "json_bulk" && c.WebhookFormat != "json_lines" {
+			return fmt.Errorf("invalid input configuration: 'input.webhook_format' must be \"text_single|text_bulk|json_single|json_bulk|json_lines\"")
 		}
 		if c.WebhookJsonSelector == "" {
 			return fmt.Errorf("invalid input configuration: 'input.webhook_json_selector' is required for input type \"webhook\"")

--- a/example/config_logstash_http_input_ipv6.yml
+++ b/example/config_logstash_http_input_ipv6.yml
@@ -27,6 +27,14 @@ input:
   # json_single: Webhook POST body is a single json log entry.  Log entry
   #   text is selected from the value of a json key determined by
   #   webhook_json_selector.
+  # json_lines: Webhook POST body contains multiple json log entries, with
+  #   newline-separated log lines holding an individual json object. JSON
+  #   object itself may not contain newlines. For example:
+  #   example:
+  #       { app="foo", stage="prod", log="example log message" }
+  #       { app="bar", stage="dev", log="another line" }
+  #   Log entry text is selected from the value of a json key determined
+  #   by webhook_json_selector.
   # json_bulk: Webhook POST body contains multiple json log entries.  The
   #   POST body envelope must be a json array "[ <entry>, <entry> ]".  Log
   #   entry text is selected from the value of a json key determined by


### PR DESCRIPTION
fluent-bit allows two JSON log formats: a stream of JSON objects not separated at all,
and one with a single JSON object per line. None of those was compatible with
grok_exporter so far. This change implements the json_lines format that is compatible
with fluent-bit.

I did not implement for v2 config, is this considered deprecated regarding new features or should the change also be included there? Runs fine with `json_lines` configuration and fluent-bit in our integration stage with some millions of log records by now.

I'd also be fine adding up some refactoring regarding duplicate code, but I wanted to propose/discuss the change first.