### PR TITLE
fix crashes on kqueue-platforms when built with go-1.14

### DIFF
--- a/tailer/fswatcher/fseventProducerLoop_darwin.go
+++ b/tailer/fswatcher/fseventProducerLoop_darwin.go
@@ -61,9 +61,11 @@ func runKeventLoop(kq int) *keventloop {
 		for {
 			eventBuf = make([]syscall.Kevent_t, 10)
 			n, err = syscall.Kevent(l.kq, nil, eventBuf, nil)
-			if err == syscall.EINTR || err == syscall.EBADF {
+			if err == syscall.EBADF {
 				// kq was closed, i.e. Close() was called.
 				return
+			} else if err == syscall.EINTR {
+				continue
 			} else if err != nil {
 				select {
 				case <-l.done:


### PR DESCRIPTION
Go 1.14 introduces asynchronous preemption, which interrupts running
goroutines by sending a SIGURG signal.  Some syscalls, like kevent(2),
will return EINTR when that happens.  grok_exporter was treating EINTR
like an error, even though no error code was set.  The result was an
eventual nil dereference.  This patch fixes the bug by restarting kevent
on EINTR.

Submitted by:	@a1exanderpetrov
Sponsored by:	Axcient
Fixes:		90