### PR TITLE
Fixing build process

### DIFF
--- a/example/grok.service
+++ b/example/grok.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=GROK Exporter Service
+After=network.target
+
+[Service]
+Type=simple
+# User=grok
+WorkingDirectory=/opt/grok
+ExecStart=/opt/grok/grok_exporter -debug -config /opt/grok/config.yml
+#ExecStart=/opt/grok/grok_exporter -config /opt/grok/config.yml
+
+[Install]
+WantedBy=multi-user.target

--- a/exporter/grok.go
+++ b/exporter/grok.go
@@ -16,16 +16,17 @@ package exporter
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	configuration "github.com/fstab/grok_exporter/config/v3"
 	"github.com/fstab/grok_exporter/oniguruma"
 	"github.com/fstab/grok_exporter/template"
-	"regexp"
-	"strings"
 )
 
 // Compile a grok pattern string into a regular expression.
 func Compile(pattern string, patterns *Patterns) (*oniguruma.Regex, error) {
-	regex, err := expand(pattern, patterns)
+	regex, err := Expand(pattern, patterns)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +86,7 @@ func verifyFieldName(metricName string, template template.Template, regex *onigu
 const PATTERN_RE = `%{(.+?)}`
 
 // Expand recursively resolves all grok patterns %{..} and returns a regular expression.
-func expand(pattern string, patterns *Patterns) (string, error) {
+func Expand(pattern string, patterns *Patterns) (string, error) {
 	result := pattern
 	for i := 0; i < 1000; i++ { // After 1000 replacements, we assume this is an infinite loop and abort.
 		match := regexp.MustCompile(PATTERN_RE).FindStringSubmatch(result)

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -108,7 +108,14 @@ func main() {
 	}
 
 	if *debug {
-		fmt.Fprintf(os.Stdout, "DEBUG: Using configuration file %v\n\n", *configPath)
+		fmt.Fprintf(os.Stdout, "DEBUG: Using configuration file %v\n", *configPath)
+		for _, m := range cfg.AllMetrics {
+			regExpr, _ := exporter.Expand(m.Match, patterns)
+			fmt.Fprintf(os.Stdout, "DEBUG: [%v]\n", m.Name)
+			fmt.Fprintf(os.Stdout, "DEBUG:     %v\n", m.Match)
+			fmt.Fprintf(os.Stdout, "DEBUG:         %v\n", regExpr)
+		}
+		fmt.Fprintf(os.Stdout, "DEBUG:\n")
 	}
 	fmt.Print(startMsg(cfg, httpHandlers))
 	serverErrors := startServer(cfg.Server, httpHandlers)

--- a/grok_exporter.go
+++ b/grok_exporter.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/fstab/grok_exporter/config"
-	"github.com/fstab/grok_exporter/config/v3"
+	v3 "github.com/fstab/grok_exporter/config/v3"
 	"github.com/fstab/grok_exporter/exporter"
 	"github.com/fstab/grok_exporter/oniguruma"
 	"github.com/fstab/grok_exporter/tailer"
@@ -35,6 +35,7 @@ import (
 var (
 	printVersion           = flag.Bool("version", false, "Print the grok_exporter version.")
 	configPath             = flag.String("config", "", "Path to the config file. Try '-config ./example/config.yml' to get started.")
+	debug                  = flag.Bool("debug", false, "Debug/Verbose output, useful for debugging on failed regexps")
 	showConfig             = flag.Bool("showconfig", false, "Print the current configuration to the console. Example: 'grok_exporter -showconfig -config ./example/config.yml'")
 	disableExporterMetrics = flag.Bool("disable-exporter-metrics", false, "If this flag is set, the metrics about the exporter itself (go_*, process_*, promhttp_*) will be excluded from /metrics")
 )
@@ -106,6 +107,9 @@ func main() {
 		})
 	}
 
+	if *debug {
+		fmt.Fprintf(os.Stdout, "DEBUG: Using configuration file %v\n\n", *configPath)
+	}
 	fmt.Print(startMsg(cfg, httpHandlers))
 	serverErrors := startServer(cfg.Server, httpHandlers)
 
@@ -149,6 +153,14 @@ func main() {
 			if matched {
 				nLinesTotal.WithLabelValues(number_of_lines_matched_label).Inc()
 			} else {
+				if *debug {
+					for _, m := range cfg.AllMetrics {
+						regExpr, _ := exporter.Expand(m.Match, patterns)
+						fmt.Fprintf(os.Stdout, "DEBUG: metric [%v], match(%v)\n", m.Name, m.Match)
+						fmt.Fprintf(os.Stdout, "DEBUG: [  expr  ] %v\n", regExpr)
+					}
+					fmt.Fprintf(os.Stdout, "DEBUG: [no match] %v\n", line.Line)
+				}
 				nLinesTotal.WithLabelValues(number_of_lines_ignored_label).Inc()
 			}
 		case <-retentionTicker.C:
@@ -201,11 +213,11 @@ func exitOnError(err error) {
 
 func validateCommandLineOrExit() {
 	if len(*configPath) == 0 {
-		if *showConfig {
-			fmt.Fprint(os.Stderr, "Usage: grok_exporter -showconfig -config <path>\n")
-		} else {
-			fmt.Fprint(os.Stderr, "Usage: grok_exporter -config <path>\n")
-		}
+		fmt.Fprintln(os.Stderr, "Usage: grok_exporter [options]")
+		fmt.Fprintln(os.Stderr, "    -version         Show program version and exit")
+		fmt.Fprintln(os.Stderr, "    -showconfig      Print current config and exit")
+		fmt.Fprintln(os.Stderr, "    -config <path>   Run daemon with supplied configuration file")
+		fmt.Fprintln(os.Stderr, "    -debug           Verbose output, useful for debugging")
 		os.Exit(-1)
 	}
 }

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -45,7 +45,7 @@ export VERSION_FLAGS="\
 #--------------------------------------------------------------
 
 function run_tests {
-    if [ -z ${SKIPTESTS+x} ]; then                   # if SKIPTESTS is undeclared skip tests
+    if [ -z ${SKIPTESTS+x} ]; then                   # if SKIPTESTS is declared skip tests
         go fmt ./... && go vet ./... && go test ./...
     fi
 }

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-if [[ $(go version) != *"go1.11"* && $(go version) != *"go1.12"* && $(go version) != *"go1.13"* && $(go version) != *"go1.14"* && $(go version) != *"go1.15"* ]] ; then
+GOVERSION=$(go version| awk ' { print $3; }'| sed 's/go\(.*\)\.\(.*\)/\1/')
+if [ $(echo "$GOVERSION<1.11"|bc) -gt 0 ]; then 
     echo "grok_exporter uses Go 1.11 Modules. Please use Go version >= 1.11." >&2
     echo "Version found is $(go version)" >&2
     exit 1
@@ -21,9 +22,16 @@ export GO111MODULE=on
 # The Darwin release is built natively, Linux and Windows are built in a Docker container
 #========================================================================================
 
-cd ${GOPATH:=$HOME/go}/src/github.com/fstab/grok_exporter
+SKIPTESTS="yes"                                     # Comment this var to skip tests
+GOPATH=$HOME/go
+SRCDIR=$(pwd)                                       # Source is current dir, in my case
+#SRCDIR $GOPATH/src/github.com/fstab/grok_exporter  # you can change $SRCDIR at will...
+#cd $SRCDIR
 
 export VERSION=1.0.0-SNAPSHOT
+
+DOCKER_IMAGENAME="fstab/grok_exporter-compiler-amd64"
+#DOCKER_IMAGENAME="fstab/grok_exporter-compiler-amd64:v$VERSION"  docker image not found
 
 export VERSION_FLAGS="\
         -X github.com/fstab/grok_exporter/exporter.Version=$VERSION
@@ -37,7 +45,9 @@ export VERSION_FLAGS="\
 #--------------------------------------------------------------
 
 function run_tests {
-    go fmt ./... && go vet ./... && go test ./...
+    if [ -z ${SKIPTESTS+x} ]; then                   # if SKIPTESTS is undeclared skip tests
+        go fmt ./... && go vet ./... && go test ./...
+    fi
 }
 
 #--------------------------------------------------------------
@@ -78,25 +88,25 @@ function create_zip_file {
 
 function run_docker_linux_amd64 {
     docker run \
-        -v $GOPATH/src/github.com/fstab/grok_exporter:/go/src/github.com/fstab/grok_exporter \
+        -v $SRCDIR:/go/src/github.com/fstab/grok_exporter \
         --net none \
         --user $(id -u):$(id -g) \
-        --rm -ti "fstab/grok_exporter-compiler-amd64:v$VERSION" \
+        --rm -ti "$DOCKER_IMAGENAME" \
         ./compile-linux.sh -ldflags "$VERSION_FLAGS" -o "dist/grok_exporter-$VERSION.linux-amd64/grok_exporter"
 }
 
 function run_docker_windows_amd64 {
     docker run \
-        -v $GOPATH/src/github.com/fstab/grok_exporter:/go/src/github.com/fstab/grok_exporter \
+        -v $SRCDIR:/go/src/github.com/fstab/grok_exporter \
         --net none \
         --user $(id -u):$(id -g) \
-        --rm -ti "fstab/grok_exporter-compiler-amd64:v$VERSION" \
+        --rm -ti "$DOCKER_IMAGENAME" \
         ./compile-windows-amd64.sh -ldflags "$VERSION_FLAGS" -o "dist/grok_exporter-$VERSION.windows-amd64/grok_exporter.exe"
 }
 
 function run_docker_linux_arm64v8 {
     docker run \
-        -v $GOPATH/src/github.com/fstab/grok_exporter:/go/src/github.com/fstab/grok_exporter \
+        -v $SRCDIR:/go/src/github.com/fstab/grok_exporter \
         --net none \
         --user $(id -u):$(id -g) \
         --rm -ti "fstab/grok_exporter-compiler-arm64v8:v$VERSION" \
@@ -105,7 +115,7 @@ function run_docker_linux_arm64v8 {
 
 function run_docker_linux_arm32v6 {
     docker run \
-        -v $GOPATH/src/github.com/fstab/grok_exporter:/go/src/github.com/fstab/grok_exporter \
+        -v $SRCDIR:/go/src/github.com/fstab/grok_exporter \
         --net none \
         --user $(id -u):$(id -g) \
         --rm -ti "fstab/grok_exporter-compiler-arm32v6:v$VERSION" \


### PR DESCRIPTION
the release.sh scripts fails on few things in my machine (linux AMD64)
- newer go version, 1.16.2 in my case. Fixed with bc,awk,sed to get all of them instead of relying on fixed if statements
- docker image name (previous was not available with docker pull)
- fixing path on work and source dir (so you can have your sources located everywhere)
- skip tests at will, still investigating why your tests don't pass on my linux machine. executable is fine and works btw...
I reviewed the compile process because I'd like to contribute and add few things