### PR TITLE
Support darwin arm64 in fswatcher

### DIFF
--- a/tailer/fswatcher/fswatcher_darwin_arm64.go
+++ b/tailer/fswatcher/fswatcher_darwin_arm64.go
@@ -1,0 +1,19 @@
+// Copyright 2018 The grok_exporter Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fswatcher
+
+func fdToInt(fd uintptr) uint64 {
+	return uint64(fd)
+}


### PR DESCRIPTION
This PR enables the fswatcher package to run on darwin arm64 (such as [Mac M1](https://en.wikipedia.org/wiki/Apple_M1) silicon). 