### PR TITLE
docs: fix paths example under “Restricting a Metric to Specific Log Files”

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -466,12 +466,12 @@ In the `input` section above, we showed that you can monitor multiple logfiles. 
   name: alice_occurrences_total
   help: number of log lines containing alice
   match: 'alice'
-  paths: /tmp/example/*.log
+  path: /tmp/example/*.log
   labels:
       logfile: '{{base .logfile}}'
 ```
 
-In the example, the `alice_occurrences_total` would only be applied to files matching `/tmp/example/*.log` and not to other files. If you have only one single path, you can use `path` as an alternative to `paths`. Note that `path` and `paths` are [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) patterns, which is not the same as Grok patterns or regular expressions.
+In the example, the `alice_occurrences_total` would only be applied to files matching `/tmp/example/*.log` and not to other files. If you have multiple paths, you can use `paths` as an alternative to `path`. Note that `path` and `paths` are [Glob](https://en.wikipedia.org/wiki/Glob_(programming)) patterns, which is not the same as Grok patterns or regular expressions.
 
 ### Expiring Old Labels
 


### PR DESCRIPTION
This PR corrects a documentation example that showed paths with a single scalar string. In the grok_exporter config schema, paths must be a YAML list ([]string). For a single glob, either use path (single string) or keep paths as a one‑item list. The current example can mislead users and cause YAML/schema validation errors at startup.

### Problem

The docs currently show:

```yaml

- type: counter
  name: alice_occurrences_total
  help: number of log lines containing alice
  match: 'alice'
  paths: /tmp/example/*.log      # <-- scalar used for `paths` (wrong type)
  labels:
    logfile: '{{base .logfile}}'

```

- `paths` is defined in the config as a list of strings (see the PathsAndGlobs struct: Path string, Paths []string).
- Using a scalar under `paths` can yield errors like `cannot unmarshal !!str into []string` or simply fail validation, depending on the parser/version.
- Elsewhere in the same document, paths is shown as a list, which makes this example inconsistent.
